### PR TITLE
maint: moved location from const to variable

### DIFF
--- a/azure/resource-group/local.tf
+++ b/azure/resource-group/local.tf
@@ -1,3 +1,0 @@
-locals {
-  location = "westeurope"
-}

--- a/azure/resource-group/main.tf
+++ b/azure/resource-group/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_resource_group" "rg" {
   name     = "rg-${var.project}-${var.environment}"
-  location = local.location
+  location = var.location
   tags     = var.tags
 }

--- a/azure/resource-group/variables.tf
+++ b/azure/resource-group/variables.tf
@@ -15,6 +15,6 @@ variable "environment" {
 
 variable "location" {
   description = "azure region where the nmbrs resource will be located"
-  type = string
-  default = "westeurope"
+  type        = string
+  default     = "westeurope"
 }

--- a/azure/resource-group/variables.tf
+++ b/azure/resource-group/variables.tf
@@ -12,3 +12,9 @@ variable "environment" {
   description = "nmbrs environment name."
   type        = string
 }
+
+variable "location" {
+  description = "azure region where the nmbrs resource will be located"
+  type = string
+  default = "westeurope"
+}

--- a/azure/vnet/main.tf
+++ b/azure/vnet/main.tf
@@ -20,14 +20,14 @@ resource "azurerm_virtual_network" "vnets" {
 }
 
 resource "azurerm_subnet" "vnet" {
-  for_each             = var.subnets
-  name                 = "sbnet-${each.value["name"]}"
-  resource_group_name  = data.azurerm_resource_group.network.name
-  address_prefixes     = each.value["address_prefixes"]
+  for_each            = var.subnets
+  name                = "sbnet-${each.value["name"]}"
+  resource_group_name = data.azurerm_resource_group.network.name
+  address_prefixes    = each.value["address_prefixes"]
 
-  depends_on           = [azurerm_virtual_network.vnets]
+  depends_on = [azurerm_virtual_network.vnets]
   #virtual_network_name = "vnet-${lookup(var.virtual_networks, each.value["vnet_key"], "wrong_vnet_key_in_vnets")["prefix"]}-${lookup(var.virtual_networks, each.value["vnet_key"], "wrong_vnet_key_in_vnets")["id"]}"
-  virtual_network_name      = lookup(azurerm_virtual_network.vnets, each.value["vnet_key"], null)["name"]
+  virtual_network_name = lookup(azurerm_virtual_network.vnets, each.value["vnet_key"], null)["name"]
 
   dynamic "delegation" {
     for_each = lookup(each.value, "delegation", [])
@@ -45,11 +45,11 @@ resource "azurerm_subnet" "vnet" {
 }
 
 resource "azurerm_virtual_network_peering" "peers" {
-  for_each                     = var.vnets_to_peer  
-  resource_group_name          = data.azurerm_resource_group.network.name
-  remote_virtual_network_id    = "/subscriptions/${data.azurerm_subscription.current.subscription_id}/resourceGroups/${data.azurerm_resource_group.network.name}/providers/Microsoft.Network/virtualNetworks/${each.value["remote_vnet_name"]}"
-  name                         = "${lookup(azurerm_virtual_network.vnets, each.value["vnet_key"], null)["name"]}_to_${each.value["remote_vnet_name"]}"
-  virtual_network_name         = lookup(azurerm_virtual_network.vnets, each.value["vnet_key"], null)["name"]  
+  for_each                  = var.vnets_to_peer
+  resource_group_name       = data.azurerm_resource_group.network.name
+  remote_virtual_network_id = "/subscriptions/${data.azurerm_subscription.current.subscription_id}/resourceGroups/${data.azurerm_resource_group.network.name}/providers/Microsoft.Network/virtualNetworks/${each.value["remote_vnet_name"]}"
+  name                      = "${lookup(azurerm_virtual_network.vnets, each.value["vnet_key"], null)["name"]}_to_${each.value["remote_vnet_name"]}"
+  virtual_network_name      = lookup(azurerm_virtual_network.vnets, each.value["vnet_key"], null)["name"]
 
-  depends_on           = [azurerm_virtual_network.vnets]
+  depends_on = [azurerm_virtual_network.vnets]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

The location is no longer a constant declared as local on the resource group resource, but a variable that the service template needs to fill in. In the future, the region value must be enforced through policy.

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
So we can support multi regions if needed, without a hard dependency at the module level.

# How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->
```diff
# module.rg.azurerm_resource_group.rg will be created
  + resource "azurerm_resource_group" "rg" {
      + id       = (known after apply)
++      + location = "westeurope"
      + name     = "rg-heimdall-aks-dev"
      + tags     = {
          + "Country"     = "nl"
          + "Environment" = "dev"
          + "Product"     = "internal"
          + "Squad"       = "infra"
          + "datadog"     = "monitored"
        }
    }
```

# Screenshots
n/a

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
