### PR TITLE
maint: moved region to a variable

### DIFF
--- a/azure/resource-group/local.tf
+++ b/azure/resource-group/local.tf
@@ -1,3 +1,0 @@
-locals {
-  location = "westeurope"
-}

--- a/azure/resource-group/main.tf
+++ b/azure/resource-group/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_resource_group" "rg" {
   name     = "rg-${var.project}-${var.environment}"
-  location = local.location
+  location = var.location
   tags     = var.tags
 }

--- a/azure/resource-group/output.tf
+++ b/azure/resource-group/output.tf
@@ -5,3 +5,7 @@ output "resource_group_name" {
 output "resource_group_id" {
   value = azurerm_resource_group.rg.id
 }
+
+output "resource_group_location" {
+  value = azurerm_resource_group.rg.location
+}

--- a/azure/resource-group/variables.tf
+++ b/azure/resource-group/variables.tf
@@ -9,14 +9,14 @@ variable "tags" {
 }
 
 variable "environment" {
-  # For a complete list of available Azure regions run at cli:  
-  # az account list-locations  --query "[].{displayName:displayName, location:name}" --output table
-  description = "(Required) The Azure Region where the Resource Group should exist. Changing this forces a new Resource Group to be created."
+  description = "nmbrs environment name."
   type        = string
 }
 
 variable "location" {
-  description = "azure resource region."
+  # For a complete list of available Azure regions run at cli:  
+  # az account list-locations  --query "[].{displayName:displayName, location:name}" --output table
+  description = "(Required) The Azure Region where the Resource Group should exist. Changing this forces a new Resource Group to be created."
   type        = string
   default     = "westeurope"
 }

--- a/azure/resource-group/variables.tf
+++ b/azure/resource-group/variables.tf
@@ -12,3 +12,9 @@ variable "environment" {
   description = "nmbrs environment name."
   type        = string
 }
+
+variable "location" {
+  description = "azure resource region."
+  type = string
+  default = "westeurope"
+}

--- a/azure/resource-group/variables.tf
+++ b/azure/resource-group/variables.tf
@@ -15,6 +15,6 @@ variable "environment" {
 
 variable "location" {
   description = "azure resource region."
-  type = string
-  default = "westeurope"
+  type        = string
+  default     = "westeurope"
 }

--- a/azure/resource-group/variables.tf
+++ b/azure/resource-group/variables.tf
@@ -9,7 +9,9 @@ variable "tags" {
 }
 
 variable "environment" {
-  description = "nmbrs environment name."
+  # For a complete list of available Azure regions run at cli:  
+  # az account list-locations  --query "[].{displayName:displayName, location:name}" --output table
+  description = "(Required) The Azure Region where the Resource Group should exist. Changing this forces a new Resource Group to be created."
   type        = string
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->

The region is now handled as a variable instead of a local, to decouple the hard dependency.
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In case we want to support multi regions, and because it should be enforced through policy instead.

# How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

```diff
# module.rg.azurerm_resource_group.rg will be created
  + resource "azurerm_resource_group" "rg" {
      + id       = (known after apply)
++      + location = "westeurope"
      + name     = "rg-heimdall-aks-dev"
      + tags     = {
          + "Country"     = "nl"
          + "Environment" = "dev"
          + "Product"     = "internal"
          + "Squad"       = "infra"
          + "datadog"     = "monitored"
        }
    }
```

# Screenshots

n/a

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
