### PR TITLE
feat(storage-account): create storage account module

### DIFF
--- a/azure/storage_account/README.md
+++ b/azure/storage_account/README.md
@@ -1,0 +1,38 @@
+# Azure Storage Account Module
+
+<p>
+  <img alt="Version" src="https://img.shields.io/badge/version-1.0.0-blue.svg" />
+  <a href="LICENSE.md" target="_blank">
+    <img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-blue.svg" />
+  </a>
+</p>
+
+This module supports the creation of Microsoft Storage Account an existent Azure resource group name.
+
+## How to use it?
+
+Fundamentally, you need to declare the module and pass the following variables in your Terraform service template:
+
+```hcl
+module "storage_account" {
+  source              = "../tf-modules/azure/storage-account"
+  project                   = "my_project"
+  environment               = "my_environment"
+  resource_group_name       = "rg-my-resource-group"
+  kind                      = "StorageV2"
+  account_tier              = "Standard"
+  replication_type          = "LRS"
+  min_tls_version           = "TLS1_2"
+  enable_https_traffic_only = true
+}
+```
+
+### Naming
+
+This module follows nmbrs naming convention but due to some restrictions imposed by [Azure resources](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftstorage) its not possible to follow it strictly.
+
+To make it easier to manage the module applies the following rule:
+- storage account name = prefix + random_id
+  - prefix= sanmbrs + environment + project (max length = 20 characters)
+  - random id = 4 hexadecimal random characters
+  

--- a/azure/storage_account/data.tf
+++ b/azure/storage_account/data.tf
@@ -1,0 +1,3 @@
+data "azurerm_resource_group" "rg" {
+  name = var.resource_group_name
+}

--- a/azure/storage_account/main.tf
+++ b/azure/storage_account/main.tf
@@ -1,0 +1,24 @@
+resource "random_id" "storage_account_name" {
+  # Arbitrary map of values that, when changed, will trigger recreation of resource
+  # See: https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id
+  keepers = {
+    environment = "${var.environment}"
+    project     = "${var.project}"
+  }
+  # Note: storage account name cannot be longer than 24 characters
+  # Prefix length <= 20 chars and random id = 4 chars (2 bytes hex)
+  prefix      = substr("sanmbrs${var.project}", 0, 20)
+  byte_length = 2
+
+}
+
+resource "azurerm_storage_account" "storage_account" {
+  name                      = random_id.storage_account_name.hex
+  resource_group_name       = data.azurerm_resource_group.rg.name
+  location                  = data.azurerm_resource_group.rg.location
+  account_kind              = var.kind
+  account_tier              = var.account_tier
+  account_replication_type  = var.replication_type
+  enable_https_traffic_only = var.enable_https_traffic_only
+  min_tls_version           = var.min_tls_version
+}

--- a/azure/storage_account/main.tf
+++ b/azure/storage_account/main.tf
@@ -7,7 +7,7 @@ resource "random_id" "storage_account_name" {
   }
   # Note: storage account name cannot be longer than 24 characters
   # Prefix length <= 20 chars and random id = 4 chars (2 bytes hex)
-  prefix      = substr("sanmbrs${var.project}", 0, 20)
+  prefix      = substr("sanmbrs${var.environment}${var.project}", 0, 20)
   byte_length = 2
 
 }

--- a/azure/storage_account/main.tf
+++ b/azure/storage_account/main.tf
@@ -5,9 +5,12 @@ resource "random_id" "storage_account_name" {
     environment = "${var.environment}"
     project     = "${var.project}"
   }
-  # Note: storage account name cannot be longer than 24 characters
-  # Prefix length <= 20 chars and random id = 4 chars (2 bytes hex)
-  prefix      = substr("sanmbrs${var.environment}${var.project}", 0, 20)
+  # Notes: 
+  # storage account name cannot be longer than 24 characters
+  # storage account name can only consist of lowercase letters and numbers
+  # Prefix length <= 20 chars and 
+  # random id = 4 chars (2 bytes hex)
+  prefix      = substr(replace(lower("sanmbrs${var.environment}${var.project}"), "/[^0-9A-Za-z]/", ""), 0, 20)
   byte_length = 2
 
 }

--- a/azure/storage_account/output.tf
+++ b/azure/storage_account/output.tf
@@ -1,0 +1,7 @@
+output "storage_account_name" {
+  value = azurerm_storage_account.storage_account.name
+}
+
+output "storage_account_id" {
+  value = azurerm_storage_account.storage_account.id
+}

--- a/azure/storage_account/terraform.tf
+++ b/azure/storage_account/terraform.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 2.97.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.1.0"
+    }
+  }
+
+  required_version = ">= 1.0.0"
+}

--- a/azure/storage_account/variables.tf
+++ b/azure/storage_account/variables.tf
@@ -28,13 +28,6 @@ variable "account_tier" {
   default     = "Standard"
 }
 
-variable "kind" {
-  # Valid options are BlobStorage, BlockBlobStorage, FileStorage, Storage and StorageV2. 
-  type        = string
-  description = "Defines the Kind of storage account."
-  default     = "StorageV2"
-}
-
 variable "replication_type" {
   # Valid options are LRS, GRS, RAGRS, ZRS, GZRS and RAGZRS.
   type        = string

--- a/azure/storage_account/variables.tf
+++ b/azure/storage_account/variables.tf
@@ -1,0 +1,56 @@
+variable "project" {
+  type        = string
+  description = "nmbrs project name."
+}
+
+variable "environment" {
+  type        = string
+  description = "environment type of the apps"
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "Resource Group used for the storage account"
+}
+
+variable "kind" {
+  # Valid options are BlobStorage, BlockBlobStorage, FileStorage, Storage and StorageV2. 
+  type        = string
+  description = "Defines the Kind of storage account."
+  default     = "StorageV2"
+}
+
+variable "account_tier" {
+  # Valid options are Standard and Premium. 
+  # For BlockBlobStorage and FileStorage accounts only Premium is valid.
+  type        = string
+  description = "Defines the Tier to use for this storage account."
+  default     = "Standard"
+}
+
+variable "kind" {
+  # Valid options are BlobStorage, BlockBlobStorage, FileStorage, Storage and StorageV2. 
+  type        = string
+  description = "Defines the Kind of storage account."
+  default     = "StorageV2"
+}
+
+variable "replication_type" {
+  # Valid options are LRS, GRS, RAGRS, ZRS, GZRS and RAGZRS.
+  type        = string
+  description = "Defines the type of replication to use for this storage account."
+  default     = "LRS"
+}
+
+variable "min_tls_version" {
+  # Valid options are TLS1_0, TLS1_1, and TLS1_2. 
+  type        = string
+  description = "The minimum supported TLS version for the storage account."
+  default     = "TLS1_2"
+}
+
+variable "enable_https_traffic_only" {
+  type        = bool
+  description = "Boolean flag which forces HTTPS if enabled"
+  default     = true
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
The idea of this PR was to create a first version of the storage account  to be used in our terraform services

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In our previous implementation, we were using the `azurerm_storage_account` module, but figuring out how to name it was a task to the developer. Also is important to keep in mind that the developer must remember 2 things:
-  storage account name cannot be longer than 24 characters
-  storage account name must be unique.

The module removes the burden of thinking about the module naming and allow us to read the `location` and `resource_group_name` from the resource group.

# How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->
A quick way to test it:

1) create a new folder in your computer and copy the `storage_account` folder to it
2) Create a new tf file (`main.tf` for example) and add the code below referencing the 'storage_account' module
```hcl
terraform {
  required_providers {
    azurerm = {
      source  = "hashicorp/azurerm"
      version = "~> 2.97.0"
    }
  }

  required_version = ">= 1.0.0"
}

provider "azurerm" {
  features {
  }
}
#########
variable "project" {
  description = "nmbrs project name."
  type        = string
  default     = "test-product"
}

variable "tags" {
  type        = map(string)
  description = "list of nmbrs mandatory resource tags."
  default = {
    country : "nl"
    squad : "infra"
    product : "test-product"
    environment : "dev"
  }

}

variable "environment" {
  type        = string
  description = "environment type of the apps"
  default     = "dev"
}

#########
module "rg" {
  source      = "git::github.com/Nmbrs/tf-modules//azure/resource-group?ref=main"
  environment = var.environment
  project     = var.project
  location    = "westeurope"
  tags        = var.tags
}

module "storage_account" {
  source = "./storage_account"

  project                   = var.project
  environment               = var.environment
  resource_group_name       = module.rg.resource_group_name
  kind                      = "StorageV2"
  account_tier              = "Standard"
  replication_type          = "LRS"
  min_tls_version           = "TLS1_2"
  enable_https_traffic_only = true

  depends_on = [module.rg]

}
```
3) `terraform init`
4) `terraform validate`
6) `terraform plan`

Output of the plan
```bash
$ terraform plan

Terraform used the selected providers to generate the following execution plan. Resource actions are
indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # module.rg.azurerm_resource_group.rg will be created
  + resource "azurerm_resource_group" "rg" {
      + id       = (known after apply)
      + location = "westeurope"
      + name     = "rg-test-product-dev"
      + tags     = {
          + "country"     = "nl"
          + "environment" = "dev"
          + "product"     = "test-product"
          + "squad"       = "infra"
        }
    }

  # module.storage_account.data.azurerm_resource_group.rg will be read during apply
  # (config refers to values not yet known)
 <= data "azurerm_resource_group" "rg"  {
      + id       = (known after apply)
      + location = (known after apply)
      + name     = "rg-test-product-dev"
      + tags     = (known after apply)

      + timeouts {
          + read = (known after apply)
        }
    }

  # module.storage_account.azurerm_storage_account.storage_account will be created
  + resource "azurerm_storage_account" "storage_account" {
      + access_tier                       = (known after apply)
      + account_kind                      = "StorageV2"
      + account_replication_type          = "LRS"
      + account_tier                      = "Standard"
      + allow_blob_public_access          = false
      + enable_https_traffic_only         = true
      + id                                = (known after apply)
      + infrastructure_encryption_enabled = false
      + is_hns_enabled                    = false
      + large_file_share_enabled          = (known after apply)
      + location                          = (known after apply)
      + min_tls_version                   = "TLS1_2"
      + name                              = (known after apply)
      + nfsv3_enabled                     = false
      + primary_access_key                = (sensitive value)
      + primary_blob_connection_string    = (sensitive value)
      + primary_blob_endpoint             = (known after apply)
      + primary_blob_host                 = (known after apply)
      + primary_connection_string         = (sensitive value)
      + primary_dfs_endpoint              = (known after apply)
      + primary_dfs_host                  = (known after apply)
      + primary_file_endpoint             = (known after apply)
      + primary_file_host                 = (known after apply)
      + primary_location                  = (known after apply)
      + primary_queue_endpoint            = (known after apply)
      + primary_queue_host                = (known after apply)
      + primary_table_endpoint            = (known after apply)
      + primary_table_host                = (known after apply)
      + primary_web_endpoint              = (known after apply)
      + primary_web_host                  = (known after apply)
      + queue_encryption_key_type         = "Service"
      + resource_group_name               = "rg-test-product-dev"
      + secondary_access_key              = (sensitive value)
      + secondary_blob_connection_string  = (sensitive value)
      + secondary_blob_endpoint           = (known after apply)
      + secondary_blob_host               = (known after apply)
      + secondary_connection_string       = (sensitive value)
      + secondary_dfs_endpoint            = (known after apply)
      + secondary_dfs_host                = (known after apply)
      + secondary_file_endpoint           = (known after apply)
      + secondary_file_host               = (known after apply)
      + secondary_location                = (known after apply)
      + secondary_queue_endpoint          = (known after apply)
      + secondary_queue_host              = (known after apply)
      + secondary_table_endpoint          = (known after apply)
      + secondary_table_host              = (known after apply)
      + secondary_web_endpoint            = (known after apply)
      + secondary_web_host                = (known after apply)
      + shared_access_key_enabled         = true
      + table_encryption_key_type         = "Service"

      + blob_properties {
          + change_feed_enabled      = (known after apply)
          + default_service_version  = (known after apply)
          + last_access_time_enabled = (known after apply)
          + versioning_enabled       = (known after apply)

          + container_delete_retention_policy {
              + days = (known after apply)
            }

          + cors_rule {
              + allowed_headers    = (known after apply)
              + allowed_methods    = (known after apply)
              + allowed_origins    = (known after apply)
              + exposed_headers    = (known after apply)
              + max_age_in_seconds = (known after apply)
            }

          + delete_retention_policy {
              + days = (known after apply)
            }
        }

      + customer_managed_key {
          + key_vault_key_id          = (known after apply)
          + user_assigned_identity_id = (known after apply)
        }

      + network_rules {
          + bypass                     = (known after apply)
          + default_action             = (known after apply)
          + ip_rules                   = (known after apply)
          + virtual_network_subnet_ids = (known after apply)

          + private_link_access {
              + endpoint_resource_id = (known after apply)
              + endpoint_tenant_id   = (known after apply)
            }
        }

      + queue_properties {
          + cors_rule {
              + allowed_headers    = (known after apply)
              + allowed_methods    = (known after apply)
              + allowed_origins    = (known after apply)
              + exposed_headers    = (known after apply)
              + max_age_in_seconds = (known after apply)
            }

          + hour_metrics {
              + enabled               = (known after apply)
              + include_apis          = (known after apply)
              + retention_policy_days = (known after apply)
              + version               = (known after apply)
            }

          + logging {
              + delete                = (known after apply)
              + read                  = (known after apply)
              + retention_policy_days = (known after apply)
              + version               = (known after apply)
              + write                 = (known after apply)
            }

          + minute_metrics {
              + enabled               = (known after apply)
              + include_apis          = (known after apply)
              + retention_policy_days = (known after apply)
              + version               = (known after apply)
            }
        }

      + routing {
          + choice                      = (known after apply)
          + publish_internet_endpoints  = (known after apply)
          + publish_microsoft_endpoints = (known after apply)
        }

      + share_properties {
          + cors_rule {
              + allowed_headers    = (known after apply)
              + allowed_methods    = (known after apply)
              + allowed_origins    = (known after apply)
              + exposed_headers    = (known after apply)
              + max_age_in_seconds = (known after apply)
            }

          + retention_policy {
              + days = (known after apply)
            }

          + smb {
              + authentication_types            = (known after apply)
              + channel_encryption_type         = (known after apply)
              + kerberos_ticket_encryption_type = (known after apply)
              + versions                        = (known after apply)
            }
        }
    }

  # module.storage_account.random_id.storage_account_name will be created
  + resource "random_id" "storage_account_name" {
      + b64_std     = (known after apply)
      + b64_url     = (known after apply)
      + byte_length = 2
      + dec         = (known after apply)
      + hex         = (known after apply)
      + id          = (known after apply)
      + keepers     = {
          + "environment" = "dev"
          + "project"     = "test-product"
        }
      + prefix      = "sanmbrstest-product"
    }

Plan: 3 to add, 0 to change, 0 to destroy.
```
# Screenshots

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
