### PR TITLE
feat(storage-account): add connection string and access key outputs

### DIFF
--- a/azure/storage_account/README.md
+++ b/azure/storage_account/README.md
@@ -15,7 +15,7 @@ Fundamentally, you need to declare the module and pass the following variables i
 
 ```hcl
 module "storage_account" {
-  source              = "../tf-modules/azure/storage-account"storage_account"
+  source              = "../tf-modules/azure/storage-account"
   name                = "sauniquename123"
   location            = "West Europe"
   resource_group_name = "rg-my-resource-group"

--- a/azure/storage_account/output.tf
+++ b/azure/storage_account/output.tf
@@ -1,7 +1,33 @@
-output "storage_account_name" {
+output "name" {
+  description = "The name of the Storage Account."
   value = azurerm_storage_account.storage_account.name
 }
 
-output "storage_account_id" {
+output "id" {
+  description = "The ID of the Storage Account."
   value = azurerm_storage_account.storage_account.id
+}
+
+output "primary_connection_string" {
+  description = "The connection string associated with the primary location."
+  value = azurerm_storage_account.storage_account.primary_connection_string
+  sensitive = true
+}
+
+output "secondary_connection_string" {
+  description = "The connection string associated with the secondary location."
+  value = azurerm_storage_account.storage_account.secondary_connection_string
+  sensitive = true
+}
+
+output "primary_access_key" {
+  description = "The primary access key for the storage account."
+  value = azurerm_storage_account.storage_account.primary_access_key
+  sensitive = true
+}
+
+output "secondary_access_key" {
+  description = "The secondary access key for the storage account."
+  value = azurerm_storage_account.storage_account.secondary_access_key
+  sensitive = true
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
The main goal of this PR is to add the connection strings and access keys for the storage account

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Since we need to output the connection string, access key and storage account name to the application pipeline, we need to expose them as outputs. In this PR the follow outputs were made available:

- primary access key
- secondary access key
- primary connection string
- secondary connection string

# How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

1. Create a new folder in your computer and copy the storage_account folder to it
2. Create a new tf file (main.tf for example) and add the code below referencing the 'storage_account' module

```hcl

terraform {
  required_providers {
    azurerm = {
      source  = "hashicorp/azurerm"
      version = "=2.98.0"
    }
  }

  required_version = ">= 1.0.0"
}

provider "azurerm" {
  features {
  }
}


variable "tags" {
  type        = map(string)
  description = "list of nmbrs mandatory resource tags."
  default = {
    country : "nl"
    squad : "infra"
    product : "test-product"
    environment : "prod"
  }

}


#########
module "rg" {
  name     = "rg-test"
  source   = "./azure/resource-group"
  location = "westeurope"
  tags     = var.tags
}

module "storage_account" {
  source              = "/home/filipe/repositories/nmbrs/tf-modules/azure/storage_account"
  name                = "sauniquename123"
  location            = "West Europe"
  resource_group_name = module.rg.name
  tags = {
    my_tag : "my_tag_value"
  }
  account_kind     = "Storage"
  account_tier     = "Standard"
  replication_type = "GRS"
}

output "name" {
  description = "The name of the Storage Account."
  value = module.storage_account.name
}

output "id" {
  description = "The ID of the Storage Account."
  value = module.storage_account.id
}

output "primary_connection_string" {
  description = "The connection string associated with the primary location."
  value = module.storage_account.primary_connection_string
  sensitive = true
}

output "secondary_connection_string" {
  description = "The connection string associated with the secondary location."
  value = module.storage_account.secondary_connection_string
  sensitive = true
}

output "primary_access_key" {
  description = "The primary access key for the storage account."
  value = module.storage_account.primary_access_key
  sensitive = true
}

output "secondary_access_key" {
  description = "The secondary access key for the storage account."
  value = module.storage_account.secondary_access_key
  sensitive = true
}
```
3. terraform init
4. terraform validate
5. terraform plan

The plan should expose the expected outputs as shown below:

```bash
Changes to Outputs:
  + id                          = (known after apply)
  + name                        = "sauniquename123"
  + primary_access_key          = (sensitive value)
  + primary_connection_string   = (sensitive value)
  + secondary_access_key        = (sensitive value)
  + secondary_connection_string = (sensitive value)
```
# Screenshots
N/A

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
