### PR TITLE
feat: embedded vault policies profiles

### DIFF
--- a/azure/keyvault/main.tf
+++ b/azure/keyvault/main.tf
@@ -27,21 +27,24 @@ resource "azurerm_key_vault_access_policy" "default_policy" {
     create_before_destroy = true
   }
 
-  key_permissions         = var.kv_key_permissions_full
   secret_permissions      = var.kv_secret_permissions_full
   certificate_permissions = var.kv_certificate_permissions_full
-  storage_permissions     = var.kv_storage_permissions_full
 }
 
-# Create an Azure Key Vault access policy
-resource "azurerm_key_vault_access_policy" "policy" {
-  for_each                = var.policies
+resource "azurerm_key_vault_access_policy" "readers_policy" {
+  for_each = toset(var.readers)
   key_vault_id            = azurerm_key_vault.key_vault.id
   tenant_id               = data.azurerm_client_config.current.tenant_id
-  object_id               = lookup(each.value, "object_id")
-  key_permissions         = lookup(each.value, "key_permissions")
-  secret_permissions      = lookup(each.value, "secret_permissions")
-  certificate_permissions = lookup(each.value, "certificate_permissions")
-  storage_permissions     = lookup(each.value, "storage_permissions")
+  object_id               = each.key
+  secret_permissions      = var.kv_secret_permissions_read
+  certificate_permissions = var.kv_certificate_permissions_read  
+}
 
+resource "azurerm_key_vault_access_policy" "writers_policy" {
+  for_each                = toset(var.writers)
+  key_vault_id            = azurerm_key_vault.key_vault.id
+  tenant_id               = data.azurerm_client_config.current.tenant_id
+  object_id               = each.key
+  secret_permissions      = var.kv_secret_permissions_write
+  certificate_permissions = var.kv_certificate_permissions_write
 }

--- a/azure/keyvault/variables.tf
+++ b/azure/keyvault/variables.tf
@@ -23,29 +23,22 @@ variable "tags" {
   description = "List of azure tag resources."
 }
 
-variable "policies" {
-  type = map(object({
-    object_id               = string
-    key_permissions         = list(string)
-    secret_permissions      = list(string)
-    certificate_permissions = list(string)
-    storage_permissions     = list(string)
-  }))
+variable "writers" {
+  type = list(string)
   description = "Define a Azure Key Vault access policy"
-  default     = {}
 }
+
+variable "readers" {
+  type = list(string)
+  description = "Define a Azure Key Vault access policy"
+}
+
+
 
 ###################################################################################################
 # from this point forward we need to analyse which ones we need to expose to the user             #
 # or stream the multiple variables in one or two that are clear for the user.                     #
 ###################################################################################################
-variable "kv_key_permissions_full" {
-  type        = list(string)
-  description = "List of full key permissions, must be one or more from the following: backup, create, decrypt, delete, encrypt, get, import, list, purge, recover, restore, sign, unwrapKey, update, verify and wrapKey."
-  default = ["backup", "create", "decrypt", "delete", "encrypt", "get", "import", "list", "purge",
-  "recover", "restore", "sign", "unwrapKey", "update", "verify", "wrapKey"]
-}
-
 variable "kv_secret_permissions_full" {
   type        = list(string)
   description = "List of full secret permissions, must be one or more from the following: backup, delete, get, list, purge, recover, restore and set"
@@ -59,19 +52,6 @@ variable "kv_certificate_permissions_full" {
   "managecontacts", "manageissuers", "purge", "recover", "setissuers", "update", "backup", "restore"]
 }
 
-variable "kv_storage_permissions_full" {
-  type        = list(string)
-  description = "List of full storage permissions, must be one or more from the following: backup, delete, deletesas, get, getsas, list, listsas, purge, recover, regeneratekey, restore, set, setsas and update"
-  default = ["backup", "delete", "deletesas", "get", "getsas", "list", "listsas",
-  "purge", "recover", "regeneratekey", "restore", "set", "setsas", "update"]
-}
-
-variable "kv_key_permissions_read" {
-  type        = list(string)
-  description = "List of read key permissions, must be one or more from the following: backup, create, decrypt, delete, encrypt, get, import, list, purge, recover, restore, sign, unwrapKey, update, verify and wrapKey"
-  default     = ["get", "list"]
-}
-
 variable "kv_secret_permissions_read" {
   type        = list(string)
   description = "List of full secret permissions, must be one or more from the following: backup, delete, get, list, purge, recover, restore and set"
@@ -81,11 +61,17 @@ variable "kv_secret_permissions_read" {
 variable "kv_certificate_permissions_read" {
   type        = list(string)
   description = "List of full certificate permissions, must be one or more from the following: backup, create, delete, deleteissuers, get, getissuers, import, list, listissuers, managecontacts, manageissuers, purge, recover, restore, setissuers and update"
-  default     = ["get", "getissuers", "list", "listissuers"]
+  default     = ["get", "list"]
 }
 
-variable "kv_storage_permissions_read" {
+variable "kv_secret_permissions_write" {
   type        = list(string)
-  description = "List of read storage permissions, must be one or more from the following: backup, delete, deletesas, get, getsas, list, listsas, purge, recover, regeneratekey, restore, set, setsas and update"
-  default     = ["get", "getsas", "list", "listsas"]
+  description = "List of full secret permissions, must be one or more from the following: backup, delete, get, list, purge, recover, restore and set"
+  default     = ["get", "list", "set"]
+}
+
+variable "kv_certificate_permissions_write" {
+  type        = list(string)
+  description = "List of full certificate permissions, must be one or more from the following: backup, create, delete, deleteissuers, get, getissuers, import, list, listissuers, managecontacts, manageissuers, purge, recover, restore, setissuers and update"
+  default     = ["get", "list", "update"]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
Given a list of writers and readers, the module should be self-sufficient to assign the rights accordingly with Nmbrs vault policies.

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The goal is to simplify the creation of vaults to the service owners, since the rights are established by the organization

# How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->
- push branch to local env.
- make sure to change the source to the right local folder
- copy/paste
```hcl
module "rg" {
  source   = "../tf-modules//azure/resource-group"
  name     = "rg-heimdall-dev"
  location = "westeurope"
  tags     = {
    Country : "nl"
    Squad : "infra"
    Product : "internal"
    Environment : "dev"
  }
}

module "vault_settings_external" {
  #source              = "git::github.com/Nmbrs/tf-modules//azure/keyvault"  
  source              = "../tf-modules//azure/keyvault"
  name                = "kv-nmbrsheimdall-dev"
  resource_group_name = "rg-heimdall-dev"
  location            = "westeurope"
  tags                = {
    Country : "nl"
    Squad : "infra"
    Product : "internal"
    Environment : "dev"
  }

  writers = ["7574db9b-72f3-431c-b068-b8769935e90c"]
  readers = ["984a10dc-52c5-4e1c-9e91-5215fa5ae26b"]

  depends_on = [
    module.rg
  ]
}
```

# Screenshots
N/A

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
