### PR TITLE
feature(keyvault): add validation to read, write and full permissions…

### DIFF
--- a/azure/keyvault/variables.tf
+++ b/azure/keyvault/variables.tf
@@ -86,7 +86,7 @@ variable "kv_secret_permissions_write" {
     condition     = alltrue([for permission in var.kv_secret_permissions_write : contains(["Backup", "Delete", "Get", "List", "Purge", "Recover", "Restore", "Set"], permission)])
     error_message = "At least one of the elements in the kv_secret_permissions_write list is invalid. Valid options are Backup, Delete, Get, List, Purge, Recover, Restore, Set."
   }
-  default     = ["get", "list", "set", "delete"]
+  default = ["get", "list", "set", "delete"]
 
 }
 
@@ -97,6 +97,6 @@ variable "kv_certificate_permissions_write" {
     condition     = alltrue([for permission in var.kv_certificate_permissions_write : contains(["Backup", "Create", "Delete", "DeleteIssuers", "Get", "GetIssuers", "Import", "List", "ListIssuers", "ManageContacts", "ManageIssuers", "Purge", "Recover", "Restore", "SetIssuers", "Update"], permission)])
     error_message = "At least one of the elements in the kv_certificate_permissions_write list is invalid. Valid options are Backup, Create, Delete, DeleteIssuers, Get, GetIssuers, Import, List, ListIssuers, ManageContacts, ManageIssuers, Purge, Recover, Restore, SetIssuers, Update."
   }
-  default     = ["get", "list", "update", "delete"]
+  default = ["get", "list", "update", "delete"]
 }
 

--- a/azure/keyvault/variables.tf
+++ b/azure/keyvault/variables.tf
@@ -24,12 +24,12 @@ variable "tags" {
 }
 
 variable "writers" {
-  type = list(string)
+  type        = list(string)
   description = "Define a Azure Key Vault access policy"
 }
 
 variable "readers" {
-  type = list(string)
+  type        = list(string)
   description = "Define a Azure Key Vault access policy"
 }
 
@@ -41,37 +41,60 @@ variable "readers" {
 ###################################################################################################
 variable "kv_secret_permissions_full" {
   type        = list(string)
-  description = "List of full secret permissions, must be one or more from the following: backup, delete, get, list, purge, recover, restore and set"
-  default     = ["backup", "delete", "get", "list", "purge", "recover", "restore", "set"]
+  description = "List of full permissions for secrets."
+  validation {
+    condition     = alltrue([for permission in var.kv_secret_permissions_full : contains(["Backup", "Delete", "Get", "List", "Purge", "Recover", "Restore", "Set"], permission)])
+    error_message = "At least one of the elements in the kv_secret_permissions_full list is invalid. Valid options are Backup, Delete, Get, List, Purge, Recover, Restore, Set."
+  }
+  default = ["Backup", "Delete", "Get", "List", "Purge", "Recover", "Restore", "Set"]
 }
 
 variable "kv_certificate_permissions_full" {
   type        = list(string)
-  description = "List of full certificate permissions, must be one or more from the following: backup, create, delete, deleteissuers, get, getissuers, import, list, listissuers, managecontacts, manageissuers, purge, recover, restore, setissuers and update"
-  default = ["create", "delete", "deleteissuers", "get", "getissuers", "import", "list", "listissuers",
-  "managecontacts", "manageissuers", "purge", "recover", "setissuers", "update", "backup", "restore"]
+  description = "List of full permissions for certificates."
+  validation {
+    condition     = alltrue([for permission in var.kv_certificate_permissions_full : contains(["Backup", "Create", "Delete", "DeleteIssuers", "Get", "GetIssuers", "Import", "List", "ListIssuers", "ManageContacts", "ManageIssuers", "Purge", "Recover", "Restore", "SetIssuers", "Update"], permission)])
+    error_message = "At least one of the elements in the kv_certificate_permissions_full list is invalid. Valid options are Backup, Create, Delete, DeleteIssuers, Get, GetIssuers, Import, List, ListIssuers, ManageContacts, ManageIssuers, Purge, Recover, Restore, SetIssuers, Update."
+  }
+  default = ["Backup", "Create", "Delete", "DeleteIssuers", "Get", "GetIssuers", "Import", "List", "ListIssuers", "ManageContacts", "ManageIssuers", "Purge", "Recover", "Restore", "SetIssuers", "Update"]
 }
 
 variable "kv_secret_permissions_read" {
   type        = list(string)
-  description = "List of full secret permissions, must be one or more from the following: backup, delete, get, list, purge, recover, restore and set"
-  default     = ["get", "list"]
+  description = "List of reading permissions for secrets."
+  validation {
+    condition     = alltrue([for permission in var.kv_secret_permissions_read : contains(["Backup", "Delete", "Get", "List", "Purge", "Recover", "Restore", "Set"], permission)])
+    error_message = "At least one of the elements in the kv_secret_permissions_read list is invalid. Valid options are Backup, Delete, Get, List, Purge, Recover, Restore, Set."
+  }
+  default = ["Get", "List"]
 }
 
 variable "kv_certificate_permissions_read" {
   type        = list(string)
-  description = "List of full certificate permissions, must be one or more from the following: backup, create, delete, deleteissuers, get, getissuers, import, list, listissuers, managecontacts, manageissuers, purge, recover, restore, setissuers and update"
-  default     = ["get", "list"]
+  description = "List of reading permissions for certificates."
+  validation {
+    condition     = alltrue([for permission in var.kv_certificate_permissions_read : contains(["Backup", "Create", "Delete", "DeleteIssuers", "Get", "GetIssuers", "Import", "List", "ListIssuers", "ManageContacts", "ManageIssuers", "Purge", "Recover", "Restore", "SetIssuers", "Update"], permission)])
+    error_message = "At least one of the elements in the kv_certificate_permissions_read list is invalid. Valid options are Backup, Create, Delete, DeleteIssuers, Get, GetIssuers, Import, List, ListIssuers, ManageContacts, ManageIssuers, Purge, Recover, Restore, SetIssuers, Update."
+  }
+  default = ["Get", "List"]
 }
 
 variable "kv_secret_permissions_write" {
   type        = list(string)
-  description = "List of full secret permissions, must be one or more from the following: backup, delete, get, list, purge, recover, restore and set"
-  default     = ["get", "list", "set"]
+  description = "List of writing permissions for secrets."
+  validation {
+    condition     = alltrue([for permission in var.kv_secret_permissions_write : contains(["Backup", "Delete", "Get", "List", "Purge", "Recover", "Restore", "Set"], permission)])
+    error_message = "At least one of the elements in the kv_secret_permissions_write list is invalid. Valid options are Backup, Delete, Get, List, Purge, Recover, Restore, Set."
+  }
+  default = ["Get", "List", "Set"]
 }
 
 variable "kv_certificate_permissions_write" {
   type        = list(string)
-  description = "List of full certificate permissions, must be one or more from the following: backup, create, delete, deleteissuers, get, getissuers, import, list, listissuers, managecontacts, manageissuers, purge, recover, restore, setissuers and update"
-  default     = ["get", "list", "update"]
+  description = "List of writing permissions for certificates."
+  validation {
+    condition     = alltrue([for permission in var.kv_certificate_permissions_write : contains(["Backup", "Create", "Delete", "DeleteIssuers", "Get", "GetIssuers", "Import", "List", "ListIssuers", "ManageContacts", "ManageIssuers", "Purge", "Recover", "Restore", "SetIssuers", "Update"], permission)])
+    error_message = "At least one of the elements in the kv_certificate_permissions_write list is invalid. Valid options are Backup, Create, Delete, DeleteIssuers, Get, GetIssuers, Import, List, ListIssuers, ManageContacts, ManageIssuers, Purge, Recover, Restore, SetIssuers, Update."
+  }
+  default = ["Get", "List", "Update"]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
The main goal of this PR is to add validation to the to read, write and full permissions variables in keyvault mode

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Since the documentation [azurerm_key_vault_access_policy] (https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) provides a list of valid values for each type of permission, the idea was to implement validation rules accordingly with the documentation. The validation should cover the following variables:

- kv_secret_permissions_full
- kv_certificate_permissions_full
- kv_secret_permissions_read
- kv_certificate_permissions_read
- kv_secret_permissions_write
- kv_certificate_permissions_write


# How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

1. Create a new folder in your computer and copy the storage_account folder to it

2. Create a new tf file (main.tf for example) and add the code below referencing the 'keyvault' module
```hcl
terraform {
  required_providers {
    azurerm = {
      source  = "hashicorp/azurerm"
      version = "~> 2.65"
    }
  }

  required_version = ">= 1.0.0"
}

provider "azurerm" {
  features {
  }
}

module "resource_group" {
  source   = "git::github.com/Nmbrs/tf-modules/azure/resource-group"
  name     = "rg-myrg-dev"
  location = "westeurope"
   tags = {
    Country : "NL"
    Squad : "Infra"
    Product : "Internal"
    Environment : "Dev"
  }
}


module "keyvault" {
  source              = "../azure/keyvault"
  name                = "kv-mytest-dev"
  location            = module.resource_group.location
  resource_group_name = module.resource_group.name
  tags = module.resource_group.tags

  writers = ["SG-SquadInfra"]
  readers = ["SG-SquadInfra"]
}
```
3. Run terraform validate and see that the code is valid
```bash
$ terraform validate
```
4. Create a new tf file (main.tf for example) and add the code below:
```hcl
module "resource_group" {
  source   = "git::github.com/Nmbrs/tf-modules/azure/resource-group"
  name     = "rg-myrg-dev"
  location = "westeurope"
   tags = {
    Country : "NL"
    Squad : "Infra"
    Product : "Internal"
    Environment : "Dev"
  }
}


module "keyvault" {
  source              = "../azure/keyvault"
  name                = "kv-mytest-dev"
  location            = module.resource_group.location
  resource_group_name = module.resource_group.name
  tags = module.resource_group.tags
  writers = ["SG-SquadInfra"]
  readers = ["SG-SquadInfra"]
  kv_secret_permissions_full = ["invalid"]
  kv_certificate_permissions_full = ["invalid"]
  kv_secret_permissions_read = ["invalid"]
  kv_certificate_permissions_read = ["invalid"]
  kv_secret_permissions_write = ["invalid"]
  kv_certificate_permissions_write = ["invalid"]
}

```
5. Run terraform validate and see that the code is invalid
```bash
$ terraform validate
```
# Screenshots

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
