### PR TITLE
feature(keyavualt): add keyvault policies validation

### DIFF
--- a/azure/keyvault/README.md
+++ b/azure/keyvault/README.md
@@ -22,9 +22,10 @@ keyvault when need.
 
 - `name` - name of the Azure resource group to be created.
 - `resource_group_name' - Specifies the Azure resource group where the keyvault will be created.
+- `external_usage` - (Optional) Specifies whether the keyvault is for internal or external use. Default value is `true`.
 - `extra_tags` - List of mandatory resource tags.
-- `external_usage` - (Optional) Specifies whether the keyvault is for internal or external use. Default value is `true`
-- `writers` and `readers` - List of Azure AD groups / apps / users.
+- `protection_enabled` - (Optional) Enables the keyvault purge protection in case of accidental deletion. Default is false.
+- `policies` - (Optional) Access policies created for the Azure Key Vault. For more information see the [policies](#policies) section.
 
 ## Module Output Variables
 
@@ -67,11 +68,50 @@ module "keyvault" {
 
 ## Policies
 
-### Permissions
+### Access policies types and permissions
 
-There're only two access policies: readers and writers, that will be applied to both secrets and certificates.
+The keyvault module supports two types of access policies which will be applied to both secrets and certificates: readers and writers. The table below indicates which policies have which permissions.
 
 | Type    | Permissions                      |
 | ------- | -------------------------------- |
 | writers | get, list, write, update, delete |
 | readers | get, list                        |
+
+### Configuring policies
+
+To configure the keyvault module to include access policies a list of objects of type policy is available for this purpose.The policy object contains the following properties:
+
+- name: Nome to security group / user / application / managed identity.
+- object_id: Azure AD's unique ID for the desired entity.
+- type: type of the desired policy. Valid options are 'readers', 'writers'.
+
+The code below exemplifies how to configure the list of policies
+
+```hcl
+  policies = [
+    # User's policy with readers access
+    {
+      name      = "User1"
+      type      = "readers"
+      object_id = "3ad33091-7b7e-4cd9-b53b-6afb2b28347c"
+    },
+    # Security groups's policy with writers access
+    {
+      name      = "SecurityGroup1"
+      type      = "writers"
+      object_id = "6dbf1a02-4950-420a-b115-553d37513bcb"
+    },
+    # Managed Identity's policy with writers access
+    {
+      name      = "ManagedIdentityX"
+      type      = "writers"
+      object_id = "a06cc7dd-c707-42cb-b500-d21ce82ffc05"
+    },
+    # Applications's policy with readers access
+    {
+      name      = "Application"
+      type      = "writers"
+      object_id = "123cad84-b095-41bd-b0fb-683db612121f"
+    },
+  ]
+```

--- a/azure/keyvault/variables.tf
+++ b/azure/keyvault/variables.tf
@@ -9,7 +9,7 @@ variable "name" {
 }
 
 variable "external_usage" {
-  description = "(Optional) Specifies whether the keyvault is for internal or external use."
+  description = "(Optional) Specifies whether the keyvault should be used internally or externally."
   type        = bool
   default     = true
 }
@@ -32,12 +32,26 @@ variable "protection_enabled" {
 }
 
 variable "policies" {
-  description = "Define an Azure Key Vault access policy."
+  description = "(Optional) Access policies created for the Azure Key Vault."
   type = list(object({
     name      = string
     object_id = string
     type      = string
   }))
   default = []
-}
 
+  validation {
+    condition     = alltrue([for policy in var.policies : can(coalesce(policy.name))])
+    error_message = "At least one 'name' property from 'policies' is invalid. They must be non-empty string values."
+  }
+
+  validation {
+    condition     = alltrue([for policy in var.policies : can(coalesce(policy.object_id))])
+    error_message = "At least one 'object_id' property from 'policies' is invalid. They must be non-empty string values."
+  }
+
+  validation {
+    condition     = alltrue([for policy in var.policies : contains(["readers", "writers"], policy.type)])
+    error_message = "At least one 'type' property from 'policies' is invalid. Valid options are 'readers', 'writers'."
+  }
+}


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->

The main goal of this PR is to create validation mechanisms for the list of policy objects designed for the keyvault. The validation mechanism must allow:
- empty list of policies
- Filled list of policies, but each property needs to be validated:
  - `name` must be a non-empty string
  - `object_id` must be a non-empty string
  - `type` valid values must be readers or writers




## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [X] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [ ] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix.
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->
- Updated `README.md` to explain how to use the policies.
- Added missing input variables in the `README.md`.
- Created a validation logic for the `name` property that only allows non-empty strings.
- Created a validation logic for the `object_id` property that only allows non-empty strings.
- Created a validation logic for the `type` property that only allows readers or writers values.

### How to test it
<!-- Please describe how to test it. -->

#### Test 1: Keyvault without policies
1. Create a new tf file (main.tf for example) at the root of this repo in your working directory and add the code below referencing the 'keyvault' module
```hcl
terraform {
  required_providers {
    azurerm = {
      source  = "hashicorp/azurerm"
      version = "~> 2.65"
    }
  }
  required_version = ">= 1.0.0"
}

provider "azurerm" {
  features {
  }
}

module "resource-group" {
  source      = "git::github.com/Nmbrs/tf-modules//azure/resource-group"
  name        = "my_project"
  environment = "Dev"
  country     = "nl"
  squad       = "infra"
  product     = "internal"
  extra_tags = {
    Datadog = "Monitored"
  }
}

module "keyvault" {
  source              = "./azure/keyvault"
  name                = "Filipe-dev"
  resource_group_name = module.resource-group.name
  extra_tags = {
    Datadog = "Monitored"
  }
}
```
2. Validate the code (Terraform validate)
3. Expected result: The code should work properly without any policy

#### Test 2: Policy with empty name
1. Create a new tf file (main.tf for example) at the root of this repo in your working directory and add the code below referencing the 'keyvault' module
```hcl
terraform {
  required_providers {
    azurerm = {
      source  = "hashicorp/azurerm"
      version = "~> 2.65"
    }
  }
  required_version = ">= 1.0.0"
}

provider "azurerm" {
  features {
  }
}

module "resource-group" {
  source      = "git::github.com/Nmbrs/tf-modules//azure/resource-group"
  name        = "my_project"
  environment = "Dev"
  country     = "nl"
  squad       = "infra"
  product     = "internal"
  extra_tags = {
    Datadog = "Monitored"
  }
}

module "keyvault" {
  source              = "./azure/keyvault"
  name                = "Filipe-dev"
  resource_group_name = module.resource-group.name
  extra_tags = {
    Datadog = "Monitored"
  }
  policies = [
    {
      name      = ""
      type      = "readers"
      object_id = "a2000afc-ddd0-416f-893f-dec7b98bc9f9"
    }
  ]
}
```
2. Validate the code (Terraform validate)
3. Expected result: The code should not work, since name must be a non-empty policy

#### Test 3: Policy with empty objectid
1. Create a new tf file (main.tf for example) at the root of this repo in your working directory and add the code below referencing the 'keyvault' module
```hcl
terraform {
  required_providers {
    azurerm = {
      source  = "hashicorp/azurerm"
      version = "~> 2.65"
    }
  }
  required_version = ">= 1.0.0"
}

provider "azurerm" {
  features {
  }
}

module "resource-group" {
  source      = "git::github.com/Nmbrs/tf-modules//azure/resource-group"
  name        = "my_project"
  environment = "Dev"
  country     = "nl"
  squad       = "infra"
  product     = "internal"
  extra_tags = {
    Datadog = "Monitored"
  }
}

module "keyvault" {
  source              = "./azure/keyvault"
  name                = "Filipe-dev"
  resource_group_name = module.resource-group.name
  extra_tags = {
    Datadog = "Monitored"
  }
  policies = [
    {
      name      = "user"
      type      = "readers"
      object_id = ""
    }
  ]
}
```
2. Validate the code (Terraform validate)
3. Expected result: The code should not work, since object_id must be a non-empty string.


#### Test 4: Policy with invalid type (not readers / writers)
1. Create a new tf file (main.tf for example) at the root of this repo in your working directory and add the code below referencing the 'keyvault' module
```hcl
terraform {
  required_providers {
    azurerm = {
      source  = "hashicorp/azurerm"
      version = "~> 2.65"
    }
  }
  required_version = ">= 1.0.0"
}

provider "azurerm" {
  features {
  }
}

module "resource-group" {
  source      = "git::github.com/Nmbrs/tf-modules//azure/resource-group"
  name        = "my_project"
  environment = "Dev"
  country     = "nl"
  squad       = "infra"
  product     = "internal"
  extra_tags = {
    Datadog = "Monitored"
  }
}

module "keyvault" {
  source              = "./azure/keyvault"
  name                = "Filipe-dev"
  resource_group_name = module.resource-group.name
  extra_tags = {
    Datadog = "Monitored"
  }
  policies = [
    {
      name      = "user"
      type      = "wrong-value"
      object_id = "a2000afc-ddd0-416f-893f-dec7b98bc9f9"
    }
  ]
}
```
2. Validate the code (Terraform validate)
3. Expected result: The code should not work, since type value must readers or writers


#### Test 5: Valid policy
1. Create a new tf file (main.tf for example) at the root of this repo in your working directory and add the code below referencing the 'keyvault' module
```hcl
terraform {
  required_providers {
    azurerm = {
      source  = "hashicorp/azurerm"
      version = "~> 2.65"
    }
  }
  required_version = ">= 1.0.0"
}

provider "azurerm" {
  features {
  }
}

module "resource-group" {
  source      = "git::github.com/Nmbrs/tf-modules//azure/resource-group"
  name        = "my_project"
  environment = "Dev"
  country     = "nl"
  squad       = "infra"
  product     = "internal"
  extra_tags = {
    Datadog = "Monitored"
  }
}

module "keyvault" {
  source              = "./azure/keyvault"
  name                = "Filipe-dev"
  resource_group_name = module.resource-group.name
  extra_tags = {
    Datadog = "Monitored"
  }
  policies = [
    {
      name      = "user"
      type      = "readers"
      object_id = "a2000afc-ddd0-416f-893f-dec7b98bc9f9"
    }
  ]
}
```
2. Validate the code (Terraform validate)
3. Expected result: The code should work properly

### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
