### PR TITLE
feature(keyvault): update network acls default behavior

### DIFF
--- a/azure/keyvault/main.tf
+++ b/azure/keyvault/main.tf
@@ -23,7 +23,7 @@ resource "azurerm_key_vault" "key_vault" {
   purge_protection_enabled = var.protection_enabled
 
   network_acls {
-    #tfsec:ignore:azure-keyvault-specify-network-ac
+    #tfsec:ignore:azure-keyvault-specify-network-acl
     default_action = "Allow"
     bypass         = "AzureServices"
   }

--- a/azure/keyvault/main.tf
+++ b/azure/keyvault/main.tf
@@ -23,7 +23,7 @@ resource "azurerm_key_vault" "key_vault" {
   purge_protection_enabled = var.protection_enabled
 
   network_acls {
-    default_action = "Deny"
+    default_action = "Allow"
     bypass         = "AzureServices"
   }
 

--- a/azure/keyvault/main.tf
+++ b/azure/keyvault/main.tf
@@ -23,6 +23,7 @@ resource "azurerm_key_vault" "key_vault" {
   purge_protection_enabled = var.protection_enabled
 
   network_acls {
+    #tfsec:ignore:azure-keyvault-specify-network-ac
     default_action = "Allow"
     bypass         = "AzureServices"
   }


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->

The main goal of this PR is to update the default network acls behavior to allow access to the keyvault from any network.

If we decide to limit access to all networks at this time, the applications will not be able to access the keyvault effectively.

As a result, while we move the resources to Terraform, access will be allowed from all networks to avoid any incompatibilities. 


## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [X] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [ ] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix.
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->
- disable tfsec rule `azure-keyvault-specify-network-acl` failed
- Update network ACLS  to allow access to the keyvault from any network.

>⚠️  The tfsec rule ` azure-keyvault-specify-network-ac` in terms of security is critical but if we implement the "fix", the apps will not access the keyvaults

### How to test it
<!-- Please describe how to test it. -->
1. Create a new tf file (main.tf for example) at the root of this repo in your working directory and add the code below referencing the 'keyvault' module
```hcl
terraform {
  required_providers {
    azurerm = {
      source  = "hashicorp/azurerm"
      version = "~> 2.65"
    }
  }
  required_version = ">= 1.0.0"
}

provider "azurerm" {
  features {
  }
}

module "resource-group" {
  source      = "git::github.com/Nmbrs/tf-modules//azure/resource-group"
  name        = "my_project"
  environment = "Dev"
  country     = "nl"
  squad       = "infra"
  product     = "internal"
  extra_tags = {
    Datadog = "Monitored"
  }
}

module "keyvault" {
  source              = "./azure/keyvault"
  name                = "Filipe-dev"
  resource_group_name = module.resource-group.name
  extra_tags = {
    Datadog = "Monitored"
  }
}
```
2. Validate the code (`terraform validate`)
3. Run the speculative plan (`terraform plan`) and check if the default network acls behavior allows access to keyvault. The following snippet should be in the plan:

```bash
      + network_acls {
          + bypass         = "AzureServices"
          + default_action = "Allow"
        }
```

### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
