### PR TITLE
feature(keyvault): add uuid regex pattern to validate object id

### DIFF
--- a/azure/keyvault/variables.tf
+++ b/azure/keyvault/variables.tf
@@ -46,8 +46,8 @@ variable "policies" {
   }
 
   validation {
-    condition     = alltrue([for policy in var.policies : can(coalesce(policy.object_id))])
-    error_message = "At least one 'object_id' property from 'policies' is invalid. They must be non-empty string values."
+    condition     = alltrue([for policy in var.policies : can(regex("^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$", policy.object_id))])
+    error_message = "At least one 'object_id' property from 'policies' is invalid. They must valid UUIDs (32 characters, separated by four hyphens). Valid example: '11111111-1111-1111-1111-111111111111'."
   }
 
   validation {


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->

The main goal of this PR is to update the validation of the AD `ObjectID` present in the keyvault policies.

To validate the ObjectID, the following regex pattern was used: 
`^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$`

![image](https://user-images.githubusercontent.com/42495290/161216228-327cd661-5559-417b-b6d6-da9f47042b79.png)


ObjectIDs basically follows the UUID pattern (32 characters in hexadecimal notation):

- first 8 characters - 8 hexadecimal chars separated by a hyphen.
- next 4 characters - 4 hexadecimal chars separated by a hyphen.
- next 4 characters - 4 hexadecimal chars separated by a hyphen.
- next 4 characters - 4 hexadecimal chars separated by a hyphen.
- final 12 characters - 12 hexadecimal chars.

Below is an example UUID:

*b22fc8e6-b18d-11ec-b909-0242ac120002*


Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [ ] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [ ] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix.
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->
-  `ObjectID` present in the keyvault policies, are being validated using UUID regex pattern 

### How to test it
<!-- Please describe how to test it. -->

#### Test 1: Keyvault without policies
1. Create a new tf file (main.tf for example) at the root of this repo in your working directory and add the code below referencing the 'keyvault' module
```hcl
terraform {
  required_providers {
    azurerm = {
      source  = "hashicorp/azurerm"
      version = "~> 2.65"
    }
  }
  required_version = ">= 1.0.0"
}

provider "azurerm" {
  features {
  }
}

module "resource-group" {
  source      = "git::github.com/Nmbrs/tf-modules//azure/resource-group"
  name        = "my_project"
  environment = "Dev"
  country     = "nl"
  squad       = "infra"
  product     = "internal"
  extra_tags = {
    Datadog = "Monitored"
  }
}

module "keyvault" {
  source              = "./azure/keyvault"
  name                = "Filipe-dev"
  resource_group_name = module.resource-group.name
  extra_tags = {
    Datadog = "Monitored"
  }
}
```
2. Validate the code (Terraform validate)
3. Expected result: The code should work properly without any policy

#### Test 2: Keyvault with a valid `ObjectID` in the policy session
1. Create a new tf file (main.tf for example) at the root of this repo in your working directory and add the code below referencing the 'keyvault' module
```hcl
terraform {
  required_providers {
    azurerm = {
      source  = "hashicorp/azurerm"
      version = "~> 2.65"
    }
  }
  required_version = ">= 1.0.0"
}

provider "azurerm" {
  features {
  }
}

module "resource-group" {
  source      = "git::github.com/Nmbrs/tf-modules//azure/resource-group"
  name        = "my_project"
  environment = "Dev"
  country     = "nl"
  squad       = "infra"
  product     = "internal"
  extra_tags = {
    Datadog = "Monitored"
  }
}

module "keyvault" {
  source              = "./azure/keyvault"
  name                = "Filipe-dev"
  resource_group_name = module.resource-group.name
  extra_tags = {
    Datadog = "Monitored"
  }
  policies = [
    {
      name      = "user1"
      type      = "readers"
      object_id = "a2000afc-ddd0-416f-893f-dec7b98bc9f9"
    }
  ]
}
```
2. Validate the code (Terraform validate)
3. Expected result: The code should work properly with a valid policy

#### Test 3: Keyvault with a invalid `ObjectID` in the policy session
1. Create a new tf file (main.tf for example) at the root of this repo in your working directory and add the code below referencing the 'keyvault' module
```hcl
terraform {
  required_providers {
    azurerm = {
      source  = "hashicorp/azurerm"
      version = "~> 2.65"
    }
  }
  required_version = ">= 1.0.0"
}

provider "azurerm" {
  features {
  }
}

module "resource-group" {
  source      = "git::github.com/Nmbrs/tf-modules//azure/resource-group"
  name        = "my_project"
  environment = "Dev"
  country     = "nl"
  squad       = "infra"
  product     = "internal"
  extra_tags = {
    Datadog = "Monitored"
  }
}

module "keyvault" {
  source              = "./azure/keyvault"
  name                = "Filipe-dev"
  resource_group_name = module.resource-group.name
  extra_tags = {
    Datadog = "Monitored"
  }
  policies = [
    {
      name      = "user1"
      type      = "readers"
      object_id = "aabc"
    }
  ]
}
```
2. Validate the code (Terraform validate)
3. Expected result: The code should not work properly without a valid policy

### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [ ] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
