### PR TITLE
feat(resource-group): remove environment var from naming convention

### DIFF
--- a/azure/resource-group/main.tf
+++ b/azure/resource-group/main.tf
@@ -1,7 +1,6 @@
 resource "azurecaf_name" "caf_name" {
   name          = lower(var.name)
   resource_type = "azurerm_resource_group"
-  suffixes      = [lower(var.environment)]
   clean_input   = true
 }
 


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->
The main purpose of this PR is to remove the environment from the resource group name, since the environments dev and test share the same resource-group.

## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [ ] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [ ] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix.
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->

- Updated `resouce-group` naming: the name is composed by `rg` prefix and the `name` variable.

### How to test it
<!-- Please describe how to test it. -->

1. At the root of the `tf-module` repository, create a `main.tf` file with the following code:`
```hcl
terraform {
  required_providers {
    azurerm = {
      source  = "hashicorp/azurerm"
      version = "~> 2.65"
    }
  }

  required_version = ">= 1.0.0"
}

provider "azurerm" {
  features {
  }
}


module "resource-group" {
  source      = "./azure/resource-group"
  name        = "new-pr-demo"
  environment = "Dev"
  country     = "nl"
  squad       = "infra"
  product     = "internal"
  extra_tags = {
    Datadog = "Monitored"
  }
}
```
2. `terraform init`
3. `terraform validate`
4. `terraform plan` and check if the speculative plan seems ok (it should contain the `resource-group` and `caf` module)
5. `terraform apply -auto-approve`
6. Check if the resource group is compose by `rg` prefix and the name `new-pr-demo`
7. After finishing testing, please don't forget to destroy the resource: `terraform destroy -auto-apply`

### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [X] Yes.
- [ ] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
