### PR TITLE
feature(keyvault): add environment variable to keyvault module

### DIFF
--- a/azure/keyvault/README.md
+++ b/azure/keyvault/README.md
@@ -22,7 +22,7 @@ keyvault when need.
 
 - `name` - name of the Azure resource group to be created.
 - `resource_group_name` - Specifies the Azure resource group where the keyvault will be created.
-- `environment` - (Optional) The environment in which the resource should be provisioned.
+- `environment` - (Optional) The environment in which the resource should be provisioned. The default value is Dev.
 - `external_usage` - (Optional) Specifies whether the keyvault is for internal or external use. Default value is `true`.
 - `extra_tags` - List of mandatory resource tags.
 - `protection_enabled` - (Optional) Enables the keyvault purge protection in case of accidental deletion. Default is false.

--- a/azure/keyvault/README.md
+++ b/azure/keyvault/README.md
@@ -21,7 +21,8 @@ keyvault when need.
 ## Module Input variables
 
 - `name` - name of the Azure resource group to be created.
-- `resource_group_name' - Specifies the Azure resource group where the keyvault will be created.
+- `resource_group_name` - Specifies the Azure resource group where the keyvault will be created.
+- `environment` - (Optional) The environment in which the resource should be provisioned.
 - `external_usage` - (Optional) Specifies whether the keyvault is for internal or external use. Default value is `true`.
 - `extra_tags` - List of mandatory resource tags.
 - `protection_enabled` - (Optional) Enables the keyvault purge protection in case of accidental deletion. Default is false.
@@ -41,6 +42,7 @@ Here is a sample that helps illustrating how to user the module on a Terraform s
 module "keyvault" {
   source = "git::github.com/Nmbrs/tf-modules//azure/keyvault"
   name                = "Heimdall"
+  environment         = "Dev"
   resource_group_name = "rg-heimdall-dev"
   extra_tags = {
     Datadog = "Monitored"

--- a/azure/keyvault/README.md
+++ b/azure/keyvault/README.md
@@ -43,7 +43,7 @@ module "keyvault" {
   source = "git::github.com/Nmbrs/tf-modules//azure/keyvault"
   name                = "Heimdall"
   environment         = "Dev"
-  resource_group_name = "rg-heimdall-dev"
+  resource_group_name = "rg-heimdall"
   extra_tags = {
     Datadog = "Monitored"
   }

--- a/azure/keyvault/local.tf
+++ b/azure/keyvault/local.tf
@@ -6,7 +6,7 @@ locals {
   internal_external_suffix = var.external_usage ? "e" : "i"
 
   org         = "nmbrs"
-  environment = data.azurerm_resource_group.rg.tags["Environment"]
+  environment = var.environment
 
   secrets_full_permissions       = ["Backup", "Delete", "Get", "List", "Purge", "Recover", "Restore", "Set"]
   certificates_full_permissions  = ["Backup", "Create", "Delete", "Deleteissuers", "Get", "Getissuers", "Import", "List", "Listissuers", "Managecontacts", "Manageissuers", "Purge", "Recover", "Restore", "Setissuers", "Update"]

--- a/azure/keyvault/variables.tf
+++ b/azure/keyvault/variables.tf
@@ -8,6 +8,17 @@ variable "name" {
   description = "The name of the Azure Key Vault."
 }
 
+variable "environment" {
+  description = "(Optional) The environment in which the resource should be provisioned."
+  type        = string
+  default     = "Dev"
+
+  validation {
+    condition     = contains(["Dev", "Kitchen", "Production", "Staging", "Test"], var.environment)
+    error_message = "The 'environment' value is invalid. Valid options are 'Dev', 'Kitchen', 'Production','Staging', 'Test'."
+  }
+}
+
 variable "external_usage" {
   description = "(Optional) Specifies whether the keyvault should be used internally or externally."
   type        = bool


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->
The main goal of this PR is to include an environment variable to keyvault module instead of using the environment tag provided by the group. By doing sos, the environment provided in existing resource-groups tags will not affect the keyvault name.

## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [X] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [ ] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix.
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->
- Add environment variable to keyvault module


### How to test it
<!-- Please describe how to test it. -->

1. At the root of the `tf-module` repository, create a `main.tf` file with the following code:`
```hcl
terraform {
  required_providers {
    azurerm = {
      source  = "hashicorp/azurerm"
      version = "~> 2.65"
    }
  }

  required_version = ">= 1.0.0"
}

provider "azurerm" {
  features {
  }
}


module "resource-group" {
  source      = "./azure/resource-group"
  name        = "heimadall-demo"
  environment = "Dev"
  country     = "nl"
  squad       = "infra"
  product     = "internal"
  extra_tags = {
    Datadog = "Monitored"
  }
}

module "keyvault" {
  source              = "./azure/keyvault"
  name                = "Heimdall"
  environment         = "Dev"
  external_usage      = true
  resource_group_name = module.resource-group.name
  extra_tags = {
    Datadog = "Monitored"
  }
}
```
2. `terraform init`
3. `terraform validate`
4. `terraform plan` and check if the speculative plan seems ok (it should contain 5 modules: the `resource-group`, `caf` module for the resource-group, `keyvault`, keyvault's default policy and `caf` module for the keyvault,)
5. `terraform apply -auto-approve`
6. Check if the resource group is composed by `kv-nmbrs` prefix, the name `heimdall` and postfix `e-dev`
7. After finishing testing, please don't forget to destroy the resource: `terraform destroy -auto-apply`

### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
