### PR TITLE
build(resource_group): update azurerm and caf providers

### DIFF
--- a/azure/resource_group/terraform.tf
+++ b/azure/resource_group/terraform.tf
@@ -2,13 +2,14 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 2.65"
+      version = "~> 3.5.0"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"
-      version = "2.0.0-preview-2"
+      version = "2.0.0-preview-3"
     }
   }
 
   required_version = ">= 1.0.0"
 }
+


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->

The main goal of this PR is to update the providers used in the `resouce_group` module:
- azurerm: https://registry.terraform.io/providers/hashicorp/azurerm/3.5.0
- azurecaf: https://registry.terraform.io/providers/aztfmod/azurecaf/latest

## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->



- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [X] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [X] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix.
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [X] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->
As described [here](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/3.0-upgrade-guide), Terraform will now check for Resources nested within a Resource Group prior to deletion of the resource group. If any items are found, an error will be raised. This behavior is configurable in the features block, but was previously disabled by default. In 3.0, this behavior will be enabled by default. 

### How to test it
<!-- Please describe how to test it. -->

1. Create a new tf file (main.tf for example) at the root of this repo in your working directory and add the code below referencing the `resource-group`module
```hcl2
terraform {
  required_providers {
    azurerm = {
      source  = "hashicorp/azurerm"
      version = "~> 3.5.0"
    }
  }
  required_version = ">= 1.0.0"
}

provider "azurerm" {
  features {
  }
}

module "resource_group" {
  source      = "./azure/resource_group"
  name        = "my_project"
  environment = "dev"
  country     = "nl"
  squad       = "infra"
  product     = "internal"
  extra_tags = {
    Datadog = "Monitored"
  }
}
```
2. Validate the code (Terraform validate)
3. Expected result: The code should work properly.


### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
