### PR TITLE
build(key_vault): update azurerm and caf providers

### DIFF
--- a/azure/key_vault/README.md
+++ b/azure/key_vault/README.md
@@ -39,8 +39,8 @@ keyvault when need.
 Here is a sample that helps illustrating how to user the module on a Terraform service
 
 ```hcl
-module "keyvault" {
-  source = "git::github.com/Nmbrs/tf-modules//azure/keyvault"
+module "key_vault" {
+  source = "git::github.com/Nmbrs/tf-modules//azure/key_vault"
   name                = "Heimdall"
   environment         = "dev"
   resource_group_name = "rg-heimdall"

--- a/azure/key_vault/local.tf
+++ b/azure/key_vault/local.tf
@@ -9,7 +9,7 @@ locals {
   environment = var.environment
 
   secrets_full_permissions       = ["Backup", "Delete", "Get", "List", "Purge", "Recover", "Restore", "Set"]
-  certificates_full_permissions  = ["Backup", "Create", "Delete", "Deleteissuers", "Get", "Getissuers", "Import", "List", "Listissuers", "Managecontacts", "Manageissuers", "Purge", "Recover", "Restore", "Setissuers", "Update"]
+  certificates_full_permissions  = ["Backup", "Create", "Delete", "DeleteIssuers", "Get", "GetIssuers", "Import", "List", "ListIssuers", "ManageContacts", "ManageIssuers", "Purge", "Recover", "Restore", "SetIssuers", "Update"]
   secrets_read_permissions       = ["Get", "List"]
   certificates_read_permissions  = ["Get", "List"]
   secrets_write_permissions      = ["Get", "List", "Set", "Delete"]

--- a/azure/key_vault/terraform.tf
+++ b/azure/key_vault/terraform.tf
@@ -2,22 +2,34 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 2.98.0"
+      version = "~> 3.5.0"
     }
-
     azurecaf = {
       source  = "aztfmod/azurecaf"
-      version = "2.0.0-preview-2"
+      version = "2.0.0-preview-3"
     }
   }
 
   required_version = ">= 1.0.0"
 }
 
+
+
 provider "azurerm" {
   features {
     key_vault {
-      purge_soft_delete_on_destroy = true
+      purge_soft_delete_on_destroy               = true
+      purge_soft_deleted_certificates_on_destroy = true
+      purge_soft_deleted_keys_on_destroy         = true
+      purge_soft_deleted_secrets_on_destroy      = true
+
+      # When recovering soft-deleted Key Vault items (Keys, Certificates, and Secrets)
+      # the Principal used by Terraform needs the "recover" permission.
+      recover_soft_deleted_key_vaults   = true
+      recover_soft_deleted_certificates = true
+      recover_soft_deleted_keys         = true
+      recover_soft_deleted_secrets      = true
+
     }
   }
 }


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->

The main goal of this PR is to update the providers used in the `key_vault` module:
- azurerm: https://registry.terraform.io/providers/hashicorp/azurerm/3.5.0
- azurecaf: https://registry.terraform.io/providers/aztfmod/azurecaf/latest

## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [X] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [X] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix.
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [X] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->
- Updated secrets full permissions list to comply with the new implemented validators. The new valid options can be seen here: 
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy#secret_permissions

- Updated certificate full permissions list to comply with the new implemented validators. The new valid options can be seen here: 
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy#certificate_permissions

- Added the new Soft Delete [features](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/3.0-upgrade-guide#soft-delete-for-key-vault) flags explicitly, preventing behavioral changes in future updates of the module

### How to test it
<!-- Please describe how to test it. -->

1. Create a new tf file (main.tf for example) at the root of this repo in your working directory and add the code below referencing the `key_vault`module
```hcl2
terraform {
  required_providers {
    azurerm = {
      source  = "hashicorp/azurerm"
      version = "~> 3.5.0"
    }
  }

  required_version = ">= 1.0.0"
}

provider "azurerm" {
  features {
  }
}

module "resource_group" {
  source      = "./azure/resource_group"
  name        = "prdemo"
  environment = "dev"
  country     = "nl"
  squad       = "infra"
  product     = "internal"
  extra_tags = {
    Datadog = "Monitored"
  }
}

module "keyvault" {
  source              = "./azure/key_vault"
  name                = "prdemo"
  environment         = "dev"
  resource_group_name = module.resource_group.name
  extra_tags          = module.resource_group.tags
}

```
2. Validate the code (Terraform validate)
3. Expected result: The code should work properly.

### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
