### PR TITLE
fix: moved to ssl binding to version v6.1.0

### DIFF
--- a/azure/app_service_windows/main.tf
+++ b/azure/app_service_windows/main.tf
@@ -40,7 +40,7 @@ resource "azurerm_app_service" "app" {
 }
 
 module "sslbinding" {
-  source                              = "git::github.com/Nmbrs/tf-modules//azure/custom_domain_binding?ref=v5.0.0"
+  source                              = "git::github.com/Nmbrs/tf-modules//azure/custom_domain_binding?ref=v6.1.0"
   apps                                = var.apps
   dns_zone_name                       = var.dns_zone_name
   dns_zone_resource_group             = var.dns_zone_resource_group


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->

The leave-absence `tf-service` is using the v6.1.0, but module is referring to other module's previous versions.

## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [ ] You complied with the code style of this project.
- [ ] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [ ] You validated all Terraform configuration files (Hint: `terraform validate`).
- [ ] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [ ] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [ ] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix.
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->

### How to test it
<!-- Please describe how to test it. -->

### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [ ] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
