### PR TITLE
fix(virtual_netowrk): update subnet index based references in tfstate

### DIFF
--- a/azure/virtual_network/main.tf
+++ b/azure/virtual_network/main.tf
@@ -13,7 +13,7 @@ resource "azurerm_virtual_network" "vnet" {
 }
 
 resource "azurerm_subnet" "subnet" {
-  for_each = { for key, value in var.subnets : key => value }
+  for_each = { for subnet in var.subnets : subnet.name => subnet }
 
   name                                           = each.value.name
   resource_group_name                            = data.azurerm_resource_group.rg.name

--- a/azure/virtual_network/variables.tf
+++ b/azure/virtual_network/variables.tf
@@ -69,6 +69,11 @@ variable "subnets" {
   }
 
   validation {
+    condition     = length([for subnet in var.subnets : subnet.name]) == length(distinct([for subnet in var.subnets : subnet.name]))
+    error_message = "At least one 'name' property from one of the 'subnets' is duplicated. They must be unique."
+  }
+
+  validation {
     condition     = alltrue([for subnet in var.subnets : alltrue([for address_prefix in subnet.address_prefixes : can(cidrhost(address_prefix, 0))])])
     error_message = "At least one of the values from 'address_prefixes' property from one of the 'subnets' is invalid. They must be valid CIDR blocks."
   }


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->

The main goal of this PR is to fix a bug  introduced in the release `7.0.0` (PR #129 ):  the elements of the subnets array are referenced in tfstate by their index rather than their name.

This is especially problematic when an element in the middle of the array is removed, changing the original indexes of the next vnets. As a result, Terraform will attempt to recreate all subnets for which the index has changed.

Also, as a "colateral damage", this PR adds uniqueness name validation for the subnets.

## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [ ] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [ ] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [X] Bugfix.
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->
N/A

### How to test it
<!-- Please describe how to test it. -->

#### Test 1: Main Usage
1 . Create a new tf file (main.tf for example) at the root of this repo in your working directory and add the code below:

```hcl
terraform {
  required_version = ">= 1.0.0, < 2.0.0"
}
provider "azurerm" {
  features {
  }
}
module "rg-01" {
  source      = "./azure/resource_group"
  name        = "my_project"
  environment = "dev"
  country     = "nl"
  squad       = "infra"
  product     = "internal"
}

module "common_network" {
  source              = "./azure/virtual_network"
  resource_group_name = module.rg-01.name
  name                = "vnet-dev-westeu-003"
  address_spaces      = ["10.90.0.0/16"]
  environment         = "dev"
  subnets = [
    {
      name                                           = "orange"
      address_prefixes                               = ["10.90.10.0/16"]
      enforce_private_link_service_network_policies  = false
      enforce_private_link_endpoint_network_policies = false
      service_endpoints                              = ["Microsoft.EventHub", "Microsoft.Web", "Microsoft.Sql"]
      delegations                                    = ["Microsoft.ContainerInstance/containerGroups", "Microsoft.Web/serverFarms", "Microsoft.Databricks/workspaces"]
    },
    {
      name                                           = "apples"
      address_prefixes                               = ["10.90.11.0/16"]
      enforce_private_link_service_network_policies  = false
      enforce_private_link_endpoint_network_policies = false
      service_endpoints                              = ["Microsoft.EventHub"]
      delegations                                    = ["Microsoft.ContainerInstance/containerGroups"]
    },
    {
      name                                           = "lemons"
      address_prefixes                               = ["10.90.12.0/16"]
      enforce_private_link_service_network_policies  = false
      enforce_private_link_endpoint_network_policies = false
      service_endpoints                              = []
      delegations                                    = []
    }
  ]
}
```
2. Validate the code (Terraform validate)
3. Check the speculative plan, and verify if the subnets are being referenced by its name instead of a numeric index, as shown below:
```bash
  # module.common_network.azurerm_subnet.subnet["apples"] will be created
  + resource "azurerm_subnet" "subnet" {
      + address_prefixes                               = [
          + "10.90.11.0/16",
        ]
      + enforce_private_link_endpoint_network_policies = false
      + enforce_private_link_service_network_policies  = false
      + id                                             = (known after apply)
      + name                                           = "apples"
      + resource_group_name                            = (known after apply)
      + service_endpoints                              = [
          + "Microsoft.EventHub",
        ]
      + virtual_network_name                           = "vnet-dev-westeu-003"

      + delegation {
          + name = "Microsoft.ContainerInstance/containerGroups"

          + service_delegation {
              + actions = [
                  + "Microsoft.Network/virtualNetworks/subnets/action",
                ]
              + name    = "Microsoft.ContainerInstance/containerGroups"
            }
        }
    }

  # module.common_network.azurerm_subnet.subnet["lemons"] will be created
  + resource "azurerm_subnet" "subnet" {
      + address_prefixes                               = [
          + "10.90.12.0/16",
        ]
      + enforce_private_link_endpoint_network_policies = false
      + enforce_private_link_service_network_policies  = false
      + id                                             = (known after apply)
      + name                                           = "lemons"
      + resource_group_name                            = (known after apply)
      + virtual_network_name                           = "vnet-dev-westeu-003"
    }

  # module.common_network.azurerm_subnet.subnet["orange"] will be created
  + resource "azurerm_subnet" "subnet" {
      + address_prefixes                               = [
          + "10.90.10.0/16",
        ]
      + enforce_private_link_endpoint_network_policies = false
      + enforce_private_link_service_network_policies  = false
      + id                                             = (known after apply)
      + name                                           = "orange"
      + resource_group_name                            = (known after apply)
      + service_endpoints                              = [
          + "Microsoft.EventHub",
          + "Microsoft.Sql",
          + "Microsoft.Web",
        ]
      + virtual_network_name                           = "vnet-dev-westeu-003"

      + delegation {
          + name = "Microsoft.ContainerInstance/containerGroups"

          + service_delegation {
              + actions = [
                  + "Microsoft.Network/virtualNetworks/subnets/action",
                ]
              + name    = "Microsoft.ContainerInstance/containerGroups"
            }
        }
      + delegation {
          + name = "Microsoft.Web/serverFarms"

          + service_delegation {
              + actions = [
                  + "Microsoft.Network/virtualNetworks/subnets/join/action",
                ]
              + name    = "Microsoft.Web/serverFarms"
            }
        }
      + delegation {
          + name = "Microsoft.Databricks/workspaces"

          + service_delegation {
              + actions = [
                  + "Microsoft.Network/virtualNetworks/subnets/join/action",
                  + "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
                  + "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
                ]
              + name    = "Microsoft.Databricks/workspaces"
            }
        }
    }
```
#### Test 2: subnet.name with duplicated values
1. Modify the code, changing `subnet.name` with duplicated values
```hcl
  subnets = [
    {
      name                                           = "apples"
      address_prefixes                               = ["10.90.10.0/16"]
      enforce_private_link_service_network_policies  = false
      enforce_private_link_endpoint_network_policies = false
      service_endpoints                              = ["Microsoft.EventHub", "Microsoft.Web", "Microsoft.Sql"]
      delegations                                    = ["Microsoft.ContainerInstance/containerGroups", "Microsoft.Web/serverFarms", "Microsoft.Databricks/workspaces"]
    },
    {
      name                                           = "apples"
      address_prefixes                               = ["10.90.11.0/16"]
      enforce_private_link_service_network_policies  = false
      enforce_private_link_endpoint_network_policies = false
      service_endpoints                              = ["Microsoft.EventHub"]
      delegations                                    = ["Microsoft.ContainerInstance/containerGroups"]
    },
    {
      name                                           = "apples"
      address_prefixes                               = ["10.90.12.0/16"]
      enforce_private_link_service_network_policies  = false
      enforce_private_link_endpoint_network_policies = false
      service_endpoints                              = []
      delegations                                    = []
    }
  ]
```

2. Run the speculative plan (terraform plan)
3. Expected result: Validation failure with the message `"At least one 'name' property from one of the 'subnets' is duplicated. They must be unique."`


### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
