### PR TITLE
fix(key_vault): update policies index based references in tfstate

### DIFF
--- a/azure/key_vault/main.tf
+++ b/azure/key_vault/main.tf
@@ -50,8 +50,8 @@ resource "azurerm_key_vault_access_policy" "default_policy" {
 
 resource "azurerm_key_vault_access_policy" "readers_policy" {
   for_each = {
-    for key, value in var.policies : key => value
-    if value.type == "readers"
+    for policy in var.policies : policy.name => policy
+    if policy.type == "readers"
   }
   key_vault_id            = azurerm_key_vault.key_vault.id
   tenant_id               = data.azurerm_client_config.current.tenant_id
@@ -62,8 +62,8 @@ resource "azurerm_key_vault_access_policy" "readers_policy" {
 
 resource "azurerm_key_vault_access_policy" "writers_policy" {
   for_each = {
-    for key, value in var.policies : key => value
-    if value.type == "writers"
+    for policy in var.policies : policy.name => policy
+    if policy.type == "writers"
   }
   key_vault_id            = azurerm_key_vault.key_vault.id
   tenant_id               = data.azurerm_client_config.current.tenant_id

--- a/azure/key_vault/variables.tf
+++ b/azure/key_vault/variables.tf
@@ -56,6 +56,11 @@ variable "policies" {
     error_message = "At least one 'name' property from 'policies' is invalid. They must be non-empty string values."
   }
 
+    validation {
+    condition     = length([for policy in var.policy : subnet.name]) == length(distinct([for policy in var.policy : policy.name]))
+    error_message = "At least one 'name' property from one of the 'policies' is duplicated. They must be unique."
+  }
+
   validation {
     condition     = alltrue([for policy in var.policies : can(regex("^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$", policy.object_id))])
     error_message = "At least one 'object_id' property from 'policies' is invalid. They must valid UUIDs (32 characters, separated by four hyphens). Valid example: '11111111-1111-1111-1111-111111111111'."

--- a/azure/key_vault/variables.tf
+++ b/azure/key_vault/variables.tf
@@ -57,7 +57,7 @@ variable "policies" {
   }
 
     validation {
-    condition     = length([for policy in var.policy : subnet.name]) == length(distinct([for policy in var.policy : policy.name]))
+    condition     = length([for policy in var.policies : policy.name]) == length(distinct([for policy in var.policies : policy.name]))
     error_message = "At least one 'name' property from one of the 'policies' is duplicated. They must be unique."
   }
 


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->
The main goal of this PR is to fix a bug present in the elements of the policy array which are referenced in tfstate by their index rather than their name.

This is especially problematic when an element in the middle of the array is removed, changing the original indexes of the next policy. As a result, Terraform will attempt to recreate all subnets for which the index has changed.

Also, as a "collateral damage", this PR adds uniqueness name validation for the policies.

## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [ ] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [ ] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [X] Bugfix.
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->

### How to test it
<!-- Please describe how to test it. -->


#### Test 1: Main Usage
1 . Create a new tf file (main.tf for example) at the root of this repo in your working directory and add the code below:

```hcl
terraform {
  required_version = ">= 1.0.0, < 2.0.0"
}
provider "azurerm" {
  features {
  }
}


module "resource_group" {
  source      = "./azure/resource_group"
  name        = "heimadall-demo"
  environment = "dev"
  country     = "nl"
  squad       = "infra"
  product     = "internal"
}

module "key_vault" {
  source              = "./azure/key_vault"
  name                = "Heimdall"
  environment         = "sand"
  external_usage      = true
  resource_group_name = module.resource_group.name
  policies = [
    {
      name      = "SG-Test1"
      type      = "writers"
      object_id = "787f69a9-2356-40f4-967a-872ad585c290"
    },
    {
      name      = "MI-Test1"
      type      = "writers"
      object_id = "5eda1d03-3085-4f0c-a6ca-81e4c4f36ece"
    },
        {
      name      = "SG-Test2"
      type      = "readers"
      object_id = "932f69a9-9956-40f4-967a-872ad585c234"
    },
    {
      name      = "MI-Test2"
      type      = "readers"
      object_id = "567a1d03-7850-4f0c-a6ca-81e4c4f36ece"
    }
  ]
}

```
2. Validate the code (Terraform validate)
3. Check the speculative plan, and verify if the policies are being referenced by its name instead of a numeric index, as shown below:
```bash
  # module.key_vault.azurerm_key_vault_access_policy.readers_policy["MI-Test2"] will be created
  + resource "azurerm_key_vault_access_policy" "readers_policy" {
      + certificate_permissions = [
          + "Get",
          + "List",
        ]
      + id                      = (known after apply)
      + key_vault_id            = (known after apply)
      + object_id               = "567a1d03-7850-4f0c-a6ca-81e4c4f36ece"
      + secret_permissions      = [
          + "Get",
          + "List",
        ]
      + tenant_id               = "xxx"
    }

  # module.key_vault.azurerm_key_vault_access_policy.readers_policy["SG-Test2"] will be created
  + resource "azurerm_key_vault_access_policy" "readers_policy" {
      + certificate_permissions = [
          + "Get",
          + "List",
        ]
      + id                      = (known after apply)
      + key_vault_id            = (known after apply)
      + object_id               = "932f69a9-9956-40f4-967a-872ad585c234"
      + secret_permissions      = [
          + "Get",
          + "List",
        ]
      + tenant_id               = "xxx"
    }

  # module.key_vault.azurerm_key_vault_access_policy.writers_policy["MI-Test1"] will be created
  + resource "azurerm_key_vault_access_policy" "writers_policy" {
      + certificate_permissions = [
          + "Get",
          + "List",
          + "Update",
          + "Delete",
        ]
      + id                      = (known after apply)
      + key_vault_id            = (known after apply)
      + object_id               = "5eda1d03-3085-4f0c-a6ca-81e4c4f36ece"
      + secret_permissions      = [
          + "Get",
          + "List",
          + "Set",
          + "Delete",
        ]
      + tenant_id               = "xxx"
    }

  # module.key_vault.azurerm_key_vault_access_policy.writers_policy["SG-Test1"] will be created
  + resource "azurerm_key_vault_access_policy" "writers_policy" {
      + certificate_permissions = [
          + "Get",
          + "List",
          + "Update",
          + "Delete",
        ]
      + id                      = (known after apply)
      + key_vault_id            = (known after apply)
      + object_id               = "787f69a9-2356-40f4-967a-872ad585c290"
      + secret_permissions      = [
          + "Get",
          + "List",
          + "Set",
          + "Delete",
        ]
      + tenant_id               = "xxx"
    }
```

#### Test 2: policies.name with duplicated values

1. Modify the code, changing `policies.name` with duplicated values
```hcl
    policies = [
    {
      name      = "SG-Test1"
      type      = "writers"
      object_id = "787f69a9-2356-40f4-967a-872ad585c290"
    },
    {
      name      = "SG-Test1"
      type      = "writers"
      object_id = "5eda1d03-3085-4f0c-a6ca-81e4c4f36ece"
    },
        {
      name      = "SG-Test1"
      type      = "readers"
      object_id = "932f69a9-9956-40f4-967a-872ad585c234"
    },
    {
      name      = "SG-Test1"
      type      = "readers"
      object_id = "567a1d03-7850-4f0c-a6ca-81e4c4f36ece"
    }
  ]
}]
```


2. Run the speculative plan (terraform plan)
3. Expected result: Validation failure with the message `"At least one 'name' property from one of the 'policies' is duplicated. They must be unique."`

### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [x] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
