### PR TITLE
feat(resource_group): update resource group tags to adhere to azure policy

### DIFF
--- a/azure/resource_group/README.md
+++ b/azure/resource_group/README.md
@@ -15,10 +15,12 @@
 
 - `name` - Name of the resource group. It must follow the CAF naming convention.
 - `location` - (Optional) Specifies the Azure Region where the resource should exists.
-- `environment` - The environment in which the resource should be provisioned. Valid options are 'Dev', 'Kitchen', 'Production','Staging', 'Test'.
-- `country` - Name of the country to which the resources belongs.
-- `squad` - Name of the squad to which the resources belongs.
-- `product` - Name of the product to which the resources belongs.
+- `environment` - The environment in which the resource should be provisioned.
+- `product` - Name of the product to which the resources belongs. Default value: "not_applicable"
+- `category`- (Optional) High level identification name that supports product componets. Default value: "not_applicable"
+- `owner` - (Optional) Name of the owner to which the resource belongs. Default value: "not_applicable"
+- `country` - Name of the country to which the resources belongs. Default value: "global"
+- `status` - (Optional) Indicates the resource state that can lead to post actions (either manually or automatically). Default value: "life_cycle"
 - `extra_tags` - (Optional) A extra mapping of tags which should be assigned to the desired resource.
 
 ## Module Output Variables
@@ -36,12 +38,14 @@ Fundamentally, you need to declare the module and pass the following variables i
 module "resource-group" {
   source                    = "git::github.com/Nmbrs/tf-modules//azure/resource-group"
   name                      = "my_project"
+  location                  = "westeurope"
   environment               = "dev"
-  country                   = "nl"
-  squad                     = "infra"
   product                   = "internal"
+  category                  = "monolith"
+  owner                     = "infra"
+  country                   = "nl" 
   extra_tags = {
-    Datadog = "Monitored"
+    datadog = "monitored"
   }
 }
 ```

--- a/azure/resource_group/local.tf
+++ b/azure/resource_group/local.tf
@@ -3,5 +3,9 @@ locals {
     environment = var.environment
     managed_by  = "terraform"
     status      = var.status
+    category    = var.category
+    owner       = var.owner
+    product     = var.product
+    country     = var.country
   }
 }

--- a/azure/resource_group/local.tf
+++ b/azure/resource_group/local.tf
@@ -1,10 +1,7 @@
 locals {
   default_tags = {
-    ProvisionedBy = "Terraform"
-    Country       = var.country
-    Squad         = var.squad
-    Product       = var.product
-    Environment   = var.environment
+    environment = var.environment
+    managed_by  = "terraform"
+    status      = var.status
   }
-
 }

--- a/azure/resource_group/main.tf
+++ b/azure/resource_group/main.tf
@@ -8,4 +8,8 @@ resource "azurerm_resource_group" "rg" {
   name     = azurecaf_name.caf_name.result
   location = var.location
   tags     = merge(var.extra_tags, local.default_tags)
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }

--- a/azure/resource_group/main.tf
+++ b/azure/resource_group/main.tf
@@ -10,6 +10,9 @@ resource "azurerm_resource_group" "rg" {
   tags     = merge(var.extra_tags, local.default_tags)
 
   lifecycle {
-    ignore_changes = [tags]
+    ignore_changes = [
+      tags["created_at"],
+      tags["updated_at"]
+    ]
   }
 }

--- a/azure/resource_group/variables.tf
+++ b/azure/resource_group/variables.tf
@@ -44,7 +44,7 @@ variable "product" {
 }
 
 variable "category" {
-  description = "(Optional) High level identification name that supports product componets."
+  description = "(Optional) High-level identification name that supports product components."
   type        = string
   default     = "not_applicable"
 

--- a/azure/resource_group/variables.tf
+++ b/azure/resource_group/variables.tf
@@ -8,58 +8,6 @@ variable "name" {
   }
 }
 
-# variable "product" {
-#   description = "Name of the product to which the resources belongs."
-#   type        = string
-
-#   validation {
-#     condition     = can(coalesce(var.product))
-#     error_message = "The 'product' value is invalid. It must be a non-empty string."
-#   }
-# }
-
-# variable "squad" {
-#   description = "Name of the squad to which the resources belongs."
-#   type        = string
-
-#   validation {
-#     condition     = can(coalesce(var.squad))
-#     error_message = "The 'squad' value is invalid. It must be a non-empty string."
-#   }
-# }
-
-# variable "country" {
-#   description = "Name of the country to which the resources belongs."
-#   type        = string
-
-#   validation {
-#     condition     = can(coalesce(var.country))
-#     error_message = "The 'country' value is invalid. It must be a non-empty string."
-#   }
-# }
-
-variable "environment" {
-  description = "The environment in which the resource should be provisioned."
-  type        = string
-  default     = "dev"
-
-  validation {
-    condition     = contains(["dev", "prod", "stag", "test", "sand"], var.environment)
-    error_message = "The 'environment' value is invalid. Valid options are 'dev', 'prod','stag', 'test', 'sand'."
-  }
-}
-
-variable "extra_tags" {
-  description = "(Optional) A extra mapping of tags which should be assigned to the desired resource."
-  type        = map(string)
-  default     = {}
-
-  validation {
-    condition     = alltrue([for tag in var.extra_tags : can(coalesce(var.extra_tags))])
-    error_message = "At least on tag value from 'extra_tags' is invalid. They must be non-empty string values."
-  }
-}
-
 variable "location" {
   # For a complete list of available Azure regions run at cli:  
   # az account list-locations  --query "[].{displayName:displayName, location:name}" --output table
@@ -73,6 +21,61 @@ variable "location" {
   }
 }
 
+variable "environment" {
+  description = "The environment in which the resource should be provisioned."
+  type        = string
+  default     = "dev"
+
+  validation {
+    condition     = contains(["dev", "prod", "stag", "test", "sand"], var.environment)
+    error_message = "The 'environment' value is invalid. Valid options are 'dev', 'prod','stag', 'test', 'sand'."
+  }
+}
+
+variable "product" {
+  description = "(Optional) Name of the product to which the resource belongs."
+  type        = string
+  default     = "not_applicable"
+
+  validation {
+    condition     = can(coalesce(var.product))
+    error_message = "The 'product' value is invalid. It must be a non-empty string."
+  }
+}
+
+variable "category" {
+  description = "(Optional) High level identification name that supports product componets."
+  type        = string
+  default     = "not_applicable"
+
+  validation {
+    condition     = can(coalesce(var.category))
+    error_message = "The 'categoy' value is invalid. It must be a non-empty string."
+  }
+}
+
+variable "owner" {
+  description = "(Optional) Name of the owner to which the resource belongs."
+  type        = string
+  default     = "not_applicable"
+
+  validation {
+    condition     = can(coalesce(var.owner))
+    error_message = "The 'owner' value is invalid. It must be a non-empty string."
+  }
+}
+
+variable "country" {
+  description = "(Optional) Name of the country to which the resources belongs."
+  type        = string
+  default     = "global"
+
+  validation {
+    condition     = contains(["global", "nl", "se"], var.country)
+    error_message = "The 'country' value is invalid. Valid options are 'global', 'nl','se'."
+  }
+}
+
 variable "status" {
   description = "(Optional) Indicates the resource state that can lead to post actions (either manually or automatically)."
   type        = string
@@ -81,5 +84,16 @@ variable "status" {
   validation {
     condition     = contains(["life_cycle", "not_compliant", "suspicious", "temporary", "to_delete", "to _review"], var.status)
     error_message = "The 'status' value is invalid. Valid options are 'life_cycle', 'not_compliant', 'suspicious', 'temporary', 'to_delete', 'to _review'."
+  }
+}
+
+variable "extra_tags" {
+  description = "(Optional) A extra mapping of tags which should be assigned to the desired resource."
+  type        = map(string)
+  default     = {}
+
+  validation {
+    condition     = alltrue([for tag in var.extra_tags : can(coalesce(var.extra_tags))])
+    error_message = "At least on tag value from 'extra_tags' is invalid. They must be non-empty string values."
   }
 }

--- a/azure/resource_group/variables.tf
+++ b/azure/resource_group/variables.tf
@@ -8,35 +8,35 @@ variable "name" {
   }
 }
 
-variable "product" {
-  description = "Name of the product to which the resources belongs."
-  type        = string
+# variable "product" {
+#   description = "Name of the product to which the resources belongs."
+#   type        = string
 
-  validation {
-    condition     = can(coalesce(var.product))
-    error_message = "The 'product' value is invalid. It must be a non-empty string."
-  }
-}
+#   validation {
+#     condition     = can(coalesce(var.product))
+#     error_message = "The 'product' value is invalid. It must be a non-empty string."
+#   }
+# }
 
-variable "squad" {
-  description = "Name of the squad to which the resources belongs."
-  type        = string
+# variable "squad" {
+#   description = "Name of the squad to which the resources belongs."
+#   type        = string
 
-  validation {
-    condition     = can(coalesce(var.squad))
-    error_message = "The 'squad' value is invalid. It must be a non-empty string."
-  }
-}
+#   validation {
+#     condition     = can(coalesce(var.squad))
+#     error_message = "The 'squad' value is invalid. It must be a non-empty string."
+#   }
+# }
 
-variable "country" {
-  description = "Name of the country to which the resources belongs."
-  type        = string
+# variable "country" {
+#   description = "Name of the country to which the resources belongs."
+#   type        = string
 
-  validation {
-    condition     = can(coalesce(var.country))
-    error_message = "The 'country' value is invalid. It must be a non-empty string."
-  }
-}
+#   validation {
+#     condition     = can(coalesce(var.country))
+#     error_message = "The 'country' value is invalid. It must be a non-empty string."
+#   }
+# }
 
 variable "environment" {
   description = "The environment in which the resource should be provisioned."
@@ -70,5 +70,16 @@ variable "location" {
   validation {
     condition     = contains(["westeurope", "northeurope"], var.location)
     error_message = "The 'location' value is invalid. Valid options are 'westeurope', 'northeurope'."
+  }
+}
+
+variable "status" {
+  description = "(Optional) Indicates the resource state that can lead to post actions (either manually or automatically)."
+  type        = string
+  default     = "life_cycle"
+
+  validation {
+    condition     = contains(["life_cycle", "not_compliant", "suspicious", "temporary", "to_delete", "to _review"], var.status)
+    error_message = "The 'status' value is invalid. Valid options are 'life_cycle', 'not_compliant', 'suspicious', 'temporary', 'to_delete', 'to _review'."
   }
 }


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->
The main goal of this PR is to update the `resource_group` module, so it can adhere to nmbrs tagging strategy and  the currently implemented azure policies.

## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [X] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [X] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix.
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->
- Added the following default_tags:
  - category. Default value: `not_applicable`
  - country. Default value: `global`
  - managed_by. The value is always terraform.
  - owner. Default value: `not_applicable`
  - status. Default value: `life_cycle`
- Removed the following default tags:
  - Provisioned_By
  - Squad
 - All default tags keys and values are in small case.

### How to test it
<!-- Please describe how to test it. -->
#### Test 1: resource group with all option parameters
1 . Create a new tf file (main.tf for example) at the root of this repo in your working directory and add the code below:
```hcl
terraform {
  required_version = ">= 1.0.0"
}

module "resource_group" {
  source      = "./azure/resource_group"
  name        = "rg-tags-001"
  location    = "westeurope"
  environment = "dev"
  product     = "mobile"
  category    = "monolith"
  owner       = "payroll"
  country     = "global"
  status      = "temporary"
  extra_tags = {
    auto_restart = "false"
  }
}
```
2. Validate the code (Terraform validate)
3. Check the speculative plan, and verify if the tags  are being created as shown below:
```bash
  # module.resource_group.azurerm_resource_group.rg will be created
  + resource "azurerm_resource_group" "rg" {
      + id       = (known after apply)
      + location = "westeurope"
      + name     = (known after apply)
      + tags     = {
          + "auto_restart" = "false"
          + "category"     = "monolith"
          + "country"      = "global"
          + "environment"  = "dev"
          + "managed_by"   = "terraform"
          + "owner"        = "payroll"
          + "product"      = "mobile"
          + "status"       = "temporary"
        }
    }
```
#### Test 2: resource group without optional parameters
1 . Create a new tf file (main.tf for example) at the root of this repo in your working directory and add the code below:
```hcl
terraform {
  required_version = ">= 1.0.0"
}


module "resource_group_no_optionals" {
  source      = "./azure/resource_group"
  name        = "rg-tags-001"
  environment = "dev"
  extra_tags = {
    auto_restart = "false"
  }
}
```
2. Validate the code (Terraform validate)
3. Check the speculative plan, and verify if the tags  are being created as shown below:
```bash
  # module.resource_group_no_optionals.azurerm_resource_group.rg will be created
  + resource "azurerm_resource_group" "rg" {
      + id       = (known after apply)
      + location = "westeurope"
      + name     = (known after apply)
      + tags     = {
          + "auto_restart" = "false"
          + "category"     = "not_applicable"
          + "country"      = "global"
          + "environment"  = "dev"
          + "managed_by"   = "terraform"
          + "owner"        = "not_applicable"
          + "product"      = "not_applicable"
          + "status"       = "life_cycle"
        }
    }
```
### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
