### PR TITLE
fix(key_vault): trim spaces and lower case acess policies indexes

### DIFF
--- a/azure/key_vault/main.tf
+++ b/azure/key_vault/main.tf
@@ -50,7 +50,7 @@ resource "azurerm_key_vault_access_policy" "default_policy" {
 
 resource "azurerm_key_vault_access_policy" "readers_policy" {
   for_each = {
-    for policy in var.policies : policy.name => policy
+    for policy in var.policies : trimspace(lower(policy.name)) => policy
     if policy.type == "readers"
   }
   key_vault_id            = azurerm_key_vault.key_vault.id
@@ -62,7 +62,7 @@ resource "azurerm_key_vault_access_policy" "readers_policy" {
 
 resource "azurerm_key_vault_access_policy" "writers_policy" {
   for_each = {
-    for policy in var.policies : policy.name => policy
+    for policy in var.policies : trimspace(lower(policy.name)) => policy
     if policy.type == "writers"
   }
   key_vault_id            = azurerm_key_vault.key_vault.id

--- a/azure/key_vault/terraform.tf
+++ b/azure/key_vault/terraform.tf
@@ -14,8 +14,6 @@ terraform {
   required_version = ">= 1.0.0, < 2.0.0"
 }
 
-
-
 provider "azurerm" {
   features {
     key_vault {

--- a/azure/key_vault/variables.tf
+++ b/azure/key_vault/variables.tf
@@ -56,8 +56,8 @@ variable "policies" {
     error_message = "At least one 'name' property from 'policies' is invalid. They must be non-empty string values."
   }
 
-    validation {
-    condition     = length([for policy in var.policies : policy.name]) == length(distinct([for policy in var.policies : policy.name]))
+  validation {
+    condition     = length([for policy in var.policies : policy.name]) == length(distinct([for policy in var.policies : trimspace(lower(policy.name))]))
     error_message = "At least one 'name' property from one of the 'policies' is duplicated. They must be unique."
   }
 


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->

## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

The main goal of this to change the names of the indexes used by the key vault's access policies, preventing components that are written identically but with different indentations from being recognized as unique elements.


- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [X] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [ ] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [X] Bugfix.
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->
- The access policies indexes with the same name, but with diffent cases or indentation, will not be considered distinct elements in terraform state

### How to test it
<!-- Please describe how to test it. -->
#### Test 1: Main usage
1. Create a new tf file (main.tf for example) at the root of this repo in your working directory and add the code below:

```hcl
terraform {
  required_version = ">= 1.0.0"
}

module "rg-01" {
  source      = "./azure/resource_group"
  name        = "pr-test"
  environment = "dev"
  country     = "nl"
  squad       = "infra"
  product     = "not_applicable"
  extra_tags = {
    managed_by = "terraform"
    category   = "not_applicable"
    owner      = "not_applicable"
    status     = "temporary"
  }
}

module "key_vault" {
  source              = "./azure/key_vault"
  name                = "kvnmbrsprindex"
  resource_group_name = module.rg-01.name
  environment         = "dev"
  external_usage      = true
  policies = [
    {
      "name" : "SG-TEST",
      "type" : "readers",
      "object_id" : "cbbff08c-1292-4e25-b07b-96d125a93e87"
    }
  ]
}
```
2. Check the speculative plan, and verify if the access_policies for `SG-TEST` is planned. The access_police should be named as  `module.key_vault.azurerm_key_vault_access_policy.readers_policy["sg-test"]`, even if the name in the policy is written in upper case.

#### Test 1: Duplicated access policies
1. Create a new tf file (main.tf for example) at the root of this repo in your working directory and add the code below:

```hcl
terraform {
  required_version = ">= 1.0.0"
}

module "rg-01" {
  source      = "./azure/resource_group"
  name        = "pr-test"
  environment = "dev"
  country     = "nl"
  squad       = "infra"
  product     = "not_applicable"
  extra_tags = {
    managed_by = "terraform"
    category   = "not_applicable"
    owner      = "not_applicable"
    status     = "temporary"
  }
}

module "key_vault" {
  source              = "./azure/key_vault"
  name                = "kvnmbrsprindex"
  resource_group_name = module.rg-01.name
  environment         = "dev"
  external_usage      = true
  policies = [
    {
      "name" : "SG-TEST",
      "type" : "readers",
      "object_id" : "cbbff08c-1292-4e25-b07b-96d125a93e87"
    },
    {
      "name" : " SG-Test ",
      "type" : "readers",
      "object_id" : "cbbff08c-1292-4e25-b07b-96d125a93e87"
    }
  ]
}
```
2. Validate the code (Terraform validate) and the following error should be thrown:

```bash
│ Error: Invalid value for variable
│ 
│   on main.tf line 26, in module "key_vault":
│   26:   policies = [
│   27:     {
│   28:       "name" : "SG-Test",
│   29:       "type" : "readers",
│   30:       "object_id" : "cbbff08c-1292-4e25-b07b-96d125a93e87"
│   31:     },
│   32:     {
│   33:       "name" : " SG-Test ",
│   34:       "type" : "readers",
│   35:       "object_id" : "cbbff08c-1292-4e25-b07b-96d125a93e87"
│   36:     }
│   37:   ]
│     ├────────────────
│     │ var.policies is list of object with 2 elements
│
│ At least one 'name' property from one of the 'policies' is duplicated. They must be unique.
```

### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
