### PR TITLE
fix(github): trim spaces and lower case repository indexes

### DIFF
--- a/github/repositories/main.tf
+++ b/github/repositories/main.tf
@@ -1,7 +1,7 @@
 module "github_repository" {
   source                 = "mineiros-io/repository/github"
   version                = "~> 0.16.0"  
-  for_each               = { for repository in var.repositories : repository.name => repository }
+  for_each               = { for repository in var.repositories : trimspace(lower(repository.name)) => repository }
   name                   = each.value.name
   description            = each.value.description
   visibility             = each.value.visibility

--- a/github/repositories/variables.tf
+++ b/github/repositories/variables.tf
@@ -15,7 +15,7 @@ variable "repositories" {
   }
 
   validation {
-    condition     = length([for repository in var.repositories : repository.name]) == length(distinct([for repository in var.repositories : repository.name]))
+    condition     = length([for repository in var.repositories : repository.name]) == length(distinct([for repository in var.repositories : trimspace(lower(repository.name))]))
     error_message = "At least one 'name' property from 'repositories' is duplicated. They must be unique."
   }
 


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->
The main goal of this to change the names of the indexes used by github's repositories, preventing components that are written identically but with different indentations from being recognized as unique elements.

## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [X] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [ ] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [X] Bugfix.
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->
- Github repositories  with the same name, but with different cases or indentation, will not be considered distinct elements in terraform state.

### How to test it
<!-- Please describe how to test it. -->
#### Test 1: Main usage
1. Create a new tf file (main.tf for example) at the root of this repo in your working directory and add the code below:
```hcl
terraform {
  required_version = ">= 1.0.0"
}


variable "github_token" {
  type      = string
  sensitive = true
}

variable "github_owner" {
  type      = string
  sensitive = true
  default   = "nmbrs"
}


module "github_repository" {
  source = "./github/repositories"

  github_token = var.github_token
  github_owner = var.github_owner
  repositories = [
    {
      "name" : "TEST-REPOSITORY",
      "description" : "The best api to feed your ducks at home.",
      "template" : "dotnet-template",
      "visibility" : "private",
      "squad" : "infra"
    }
  ]
}
```
2. Check the speculative plan, and verify if the repository `TEST-REPOSITORY` is planned. The repo should be named as module.github_repository.module.github_repository["testing-repository"].github_repository.repository, even if the name of the policy is written in upper case.

#### Test 2: duplicated repositories
1. Create a new tf file (main.tf for example) at the root of this repo in your working directory and add the code below:
```hcl
terraform {
  required_version = ">= 1.0.0"
}


variable "github_token" {
  type      = string
  sensitive = true
}

variable "github_owner" {
  type      = string
  sensitive = true
  default   = "nmbrs"
}


module "github_repository" {
  source = "./github/repositories"

  github_token = var.github_token
  github_owner = var.github_owner
  repositories = [
    {
      "name" : "TESTING-REPOSITORY",
      "description" : "The best api to feed your ducks at home.",
      "template" : "dotnet-template",
      "visibility" : "private",
      "squad" : "infra"
    },
    {
      "name" : " Testing-repository ",
      "description" : "The best api to feed your ducks at home.",
      "template" : "dotnet-template",
      "visibility" : "private",
      "squad" : "infra"
    }
  ]
}
```
2.Validate the code (Terraform validate) and the following error should be thrown:
```bash
│ Error: Invalid value for variable
│ 
│   on main.tf line 114, in module "github_repository":
│  114:   repositories = [
│  115:     {
│  116:       "name" : "TESTING-REPOSITORY",
│  117:       "description" : "The best api to feed your ducks at home.",
│  118:       "template" : "dotnet-template",
│  119:       "visibility" : "private",
│  120:       "squad" : "infra"
│  121:     },
│  122:     {
│  123:       "name" : " Testing-repository ",
│  124:       "description" : "The best api to feed your ducks at home.",
│  125:       "template" : "dotnet-template",
│  126:       "visibility" : "private",
│  127:       "squad" : "infra"
│  128:     }
│  129:   ]
│     ├────────────────
│     │ var.repositories is list of object with 2 elements
│ 
│ At least one 'name' property from 'repositories' is duplicated. They must be unique.
```
### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
