### PR TITLE
feat(key_vault): add readers and writers policies outputs

### DIFF
--- a/azure/key_vault/output.tf
+++ b/azure/key_vault/output.tf
@@ -12,3 +12,21 @@ output "uri" {
   description = "The URI of the Key Vault, used for performing operations on keys and secrets."
   value       = azurerm_key_vault.key_vault.vault_uri
 }
+
+output "readers_policies" {
+  description = "List of readers access policies."
+  value = [for policy in azurerm_key_vault_access_policy.readers_policy : {
+    name      = var.policies[index(var.policies.*.object_id, policy.object_id)].name
+    object_id = policy.object_id
+    }
+  ]
+}
+
+output "writers_policies" {
+  description = "List of writers access policies."
+  value = [for policy in azurerm_key_vault_access_policy.writers_policy : {
+    name      = var.policies[index(var.policies.*.object_id, policy.object_id)].name
+    object_id = policy.object_id
+    }
+  ]
+}


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->
The main goal of this PR is to add readers and writers policies outputs, making this information available for automation systems and tools in a service level.

## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [ ] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [ ] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix.
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->
- Added readers access policies output  `output.tf` file
- Added writers access policies output  `output.tf` file

### How to test it
<!-- Please describe how to test it. -->
1. Create a new tf file (main.tf for example) at the root of this repo in your working directory and add the code below:
```hcl
terraform {
  required_version = ">= 1.0.0"
}

provider "azurerm" {
  features {

  }
}

module "rg-01" {
  source      = "./azure/resource_group"
  name        = "pr-testffs"
  environment = "dev"
  country     = "nl"
  squad       = "infra"
  product     = "not_applicable"
  extra_tags = {
    managed_by = "terraform"
    category   = "not_applicable"
    owner      = "not_applicable"
    status     = "temporary"
  }
}

module "key_vault" {
  source              = "./azure/key_vault"
  name                = "kvnmbrsprindexf"
  resource_group_name = module.rg-01.name
  environment         = "dev"
  external_usage      = true
  policies = [
    {
      "name" : "Test1",
      "type" : "writers",
      "object_id" : "627c8b37-2edc-4869-aa81-9a38fbe4cea9"
    },
    {
      "name" : "Test2"
      "type" : "writers",
      "object_id" : "b87d4e8c-67ee-4bb4-a92c-71ae00406c11"
    },
    {
      "name" : "Test3"
      "type" : "writers",
      "object_id" : "8b47b641-f8a5-47c2-bede-5613cb243e7c"
    },
    {
      "name" : "Test4"
      "type" : "readers",
      "object_id" : "e2ecdd87-c0bb-4a7d-8469-905af75e4d35"
    },
    {
      "name" : "Test5"
      "type" : "writers",
      "object_id" : "e73c6cd5-f033-4592-97d1-bbccaf53ea91"
    },
    {
      "name" : "Test6"
      "type" : "readers",
      "object_id" : "08476d3b-ddcd-4bb0-83f5-d68874fc9c03"
    }
  ]
}


output "readers_policies" {
  value = module.key_vault.readers_policies
}

output "writers_policies" {
  value = module.key_vault.writers_policies
}
```

2. Check the speculative plan, and verify if the outputs are presented as shown below:
```bash
Changes to Outputs:
  + id               = (known after apply)
  + name             = (known after apply)
  + readers_policies = [
      + {
          + name      = "Test4"
          + object_id = "e2ecdd87-c0bb-4a7d-8469-905af75e4d35"
        },
      + {
          + name      = "Test6"
          + object_id = "08476d3b-ddcd-4bb0-83f5-d68874fc9c03"
        },
    ]
  + uri              = (known after apply)
  + writers_policies = [
      + {
          + name      = "Test1"
          + object_id = "627c8b37-2edc-4869-aa81-9a38fbe4cea9"
        },
      + {
          + name      = "Test2"
          + object_id = "b87d4e8c-67ee-4bb4-a92c-71ae00406c11"
        },
      + {
          + name      = "Test3"
          + object_id = "8b47b641-f8a5-47c2-bede-5613cb243e7c"
        },
      + {
          + name      = "Test5"
          + object_id = "e73c6cd5-f033-4592-97d1-bbccaf53ea91"
        },
    ]
```

### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
