### PR TITLE
feat(key_vault): ignore updated_at and created_at tags

### DIFF
--- a/azure/key_vault/main.tf
+++ b/azure/key_vault/main.tf
@@ -30,6 +30,13 @@ resource "azurerm_key_vault" "key_vault" {
 
   // extra_tags is on the end to overwrite incorrect tags that already exists.
   tags = merge(local.default_tags, data.azurerm_resource_group.rg.tags, var.extra_tags)
+
+  lifecycle {
+    ignore_changes = [
+      tags["created_at"],
+      tags["updated_at"]
+    ]
+  }
 }
 
 # Create a Default Azure Key Vault access policy with Admin permissions


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->

The main goal of this PR is to ignore the tags `created_at` and `updated_at` managed by the custom Azure's policies implemented at nmbrs

## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [X] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [ ] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix.
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->

### How to test it
<!-- Please describe how to test it. -->
1. Go to tf-service and pick-up a service with a recently deployed key_vaults. A good candidate would be `invoicing` service from `dev` environment.
2. Initialize terraform (`terraform init`) and run the speculative plan (`terraform plan`). The tags `created_by` and `updated_at` should be replaced by a null value accordingly with tf-plan
3. At the `main.tf` from `invoicing` service, replace the remote reference in the `source` paramater with the local absolute path of the `key_vault` from this branch, as shown in the example below:

```hcl
module "keyvault_external" {
  source              = "/Users/xxxx/repositories/nmbrs/tf-modules/azure/key_vault"
  name                = var.overwrite_keyvault_name
  resource_group_name = module.resource_group.name
  external_usage      = true
  environment         = var.environment
  policies            = var.policies_external
}
```
4. Run the speculative plan and verify it. The tags `created_at` and `updated_at` should not be present in the list of changes


### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
