### PR TITLE
feat(key_vault): add key and storage permissions to access policies

### DIFF
--- a/azure/key_vault/local.tf
+++ b/azure/key_vault/local.tf
@@ -8,10 +8,18 @@ locals {
   org         = "nmbrs"
   environment = var.environment
 
-  secrets_full_permissions       = ["Backup", "Delete", "Get", "List", "Purge", "Recover", "Restore", "Set"]
-  certificates_full_permissions  = ["Backup", "Create", "Delete", "DeleteIssuers", "Get", "GetIssuers", "Import", "List", "ListIssuers", "ManageContacts", "ManageIssuers", "Purge", "Recover", "Restore", "SetIssuers", "Update"]
-  secrets_read_permissions       = ["Get", "List"]
-  certificates_read_permissions  = ["Get", "List"]
-  secrets_write_permissions      = ["Get", "List", "Set", "Delete"]
+  certificates_full_permissions = ["Backup", "Create", "Delete", "DeleteIssuers", "Get", "GetIssuers", "Import", "List", "ListIssuers", "ManageContacts", "ManageIssuers", "Purge", "Recover", "Restore", "SetIssuers", "Update"]
+  keys_full_permissions         = []
+  secrets_full_permissions      = ["Backup", "Delete", "Get", "List", "Purge", "Recover", "Restore", "Set"]
+  storage_full_permissions      = []
+
+  certificates_read_permissions = ["Get", "List"]
+  keys_read_permissions         = []
+  secrets_read_permissions      = ["Get", "List"]
+  storage_read_permissions      = []
+
   certificates_write_permissions = ["Get", "List", "Update", "Delete"]
+  keys_write_permissions         = []
+  secrets_write_permissions      = ["Get", "List", "Set", "Delete"]
+  storage_write_permissions      = []
 }

--- a/azure/key_vault/main.tf
+++ b/azure/key_vault/main.tf
@@ -40,9 +40,9 @@ resource "azurerm_key_vault_access_policy" "default_policy" {
   object_id    = data.azurerm_client_config.current.object_id
 
   certificate_permissions = local.certificates_full_permissions
-  key_permissions         = []
+  key_permissions         = local.keys_full_permissions
   secret_permissions      = local.secrets_full_permissions
-  storage_permissions     = []
+  storage_permissions     = local.storage_full_permissions
 
   lifecycle {
     create_before_destroy = true
@@ -58,9 +58,9 @@ resource "azurerm_key_vault_access_policy" "readers_policy" {
   tenant_id               = data.azurerm_client_config.current.tenant_id
   object_id               = each.value.object_id
   certificate_permissions = local.certificates_read_permissions
-  key_permissions         = []
+  key_permissions         = local.keys_read_permissions
   secret_permissions      = local.secrets_read_permissions
-  storage_permissions     = []
+  storage_permissions     = local.storage_read_permissions
 }
 
 resource "azurerm_key_vault_access_policy" "writers_policy" {
@@ -72,7 +72,7 @@ resource "azurerm_key_vault_access_policy" "writers_policy" {
   tenant_id               = data.azurerm_client_config.current.tenant_id
   object_id               = each.value.object_id
   certificate_permissions = local.certificates_write_permissions
-  key_permissions         = []
+  key_permissions         = local.keys_write_permissions
   secret_permissions      = local.secrets_write_permissions
-  storage_permissions     = []
+  storage_permissions     = local.storage_write_permissions
 }

--- a/azure/key_vault/main.tf
+++ b/azure/key_vault/main.tf
@@ -39,14 +39,15 @@ resource "azurerm_key_vault_access_policy" "default_policy" {
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = data.azurerm_client_config.current.object_id
 
+  certificate_permissions = local.certificates_full_permissions
+  key_permissions         = []
+  secret_permissions      = local.secrets_full_permissions
+  storage_permissions     = []
+
   lifecycle {
     create_before_destroy = true
   }
-
-  secret_permissions      = local.secrets_full_permissions
-  certificate_permissions = local.certificates_full_permissions
 }
-
 
 resource "azurerm_key_vault_access_policy" "readers_policy" {
   for_each = {
@@ -56,8 +57,10 @@ resource "azurerm_key_vault_access_policy" "readers_policy" {
   key_vault_id            = azurerm_key_vault.key_vault.id
   tenant_id               = data.azurerm_client_config.current.tenant_id
   object_id               = each.value.object_id
-  secret_permissions      = local.secrets_read_permissions
   certificate_permissions = local.certificates_read_permissions
+  key_permissions         = []
+  secret_permissions      = local.secrets_read_permissions
+  storage_permissions     = []
 }
 
 resource "azurerm_key_vault_access_policy" "writers_policy" {
@@ -68,6 +71,8 @@ resource "azurerm_key_vault_access_policy" "writers_policy" {
   key_vault_id            = azurerm_key_vault.key_vault.id
   tenant_id               = data.azurerm_client_config.current.tenant_id
   object_id               = each.value.object_id
-  secret_permissions      = local.secrets_write_permissions
   certificate_permissions = local.certificates_write_permissions
+  key_permissions         = []
+  secret_permissions      = local.secrets_write_permissions
+  storage_permissions     = []
 }


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->
The main goal of this PR is to include the properties `key_permissions` and `storage_permissions` in kv's access policies, ensuring that no diffs relating to these keys appear in speculative plans. 

## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [x] You complied with the code style of this project.
- [x] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [x] You validated all Terraform configuration files (Hint: `terraform validate`).
- [x] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [ ] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [ ] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix.
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->
- Diffs related to `key_permissions` and `storage_permissions` should not be displayed in the speculative plan

### How to test it
<!-- Please describe how to test it. -->
1. In `tf-services`, select the invoicing service from dev environment and change the key_vault module, pointing to your local tf-module. 
2. Run terraform plan and the speculative plan should not display diffs related with `key_permissions` and `storage_permissions` 

### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
