### PR TITLE
feat(key_vault): add managed_by tag

### DIFF
--- a/azure/key_vault/local.tf
+++ b/azure/key_vault/local.tf
@@ -1,6 +1,6 @@
 locals {
   default_tags = {
-    ProvisionedBy = "Terraform"
+    managed_by = "terraform"
   }
 
   internal_external_suffix = var.external_usage ? "e" : "i"


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->
The main goal of this PR is to remove the `ProvisionedBy` tag and add the `managed_by` tag, ensuring that the key_vault module complies with Nmbrs tagging strategy

## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [ ] You complied with the code style of this project.
- [ ] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [ ] You validated all Terraform configuration files (Hint: `terraform validate`).
- [ ] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [ ] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [ ] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix.
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->
- Remove `ProsivisonedBy` tag
- Add `managed_by`tag

### How to test it
<!-- Please describe how to test it. -->
1. Create a new tf file (main.tf for example) at the root of this repo in your working directory and add the code below:
```hcl
terraform {
  required_version = ">= 1.0.0"
}

module "rg-01" {
  source      = "./azure/resource_group"
  name        = "pr-test"
  environment = "dev"
  country     = "nl"
  squad       = "infra"
  product     = "not_applicable"
  extra_tags = {
    managed_by = "terraform"
    category   = "not_applicable"
    owner      = "not_applicable"
    status     = "temporary"
  }
}

module "key_vault" {
  source              = "./azure/key_vault"
  name                = "kvnmbrsprindex"
  resource_group_name = module.rg-01.name
  environment         = "dev"
  external_usage      = true
  policies = [
    {
      "name" : "SG-TEST",
      "type" : "readers",
      "object_id" : "cbbff08c-1292-4e25-b07b-96d125a93e87"
    }
  ]
}
```
2. Check the speculative plan, and verify tag `managed_by` is present
### Does this PR introduce a breaking change?
- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
