### PR TITLE
fix(key_vault): update default tags precedence

### DIFF
--- a/azure/key_vault/main.tf
+++ b/azure/key_vault/main.tf
@@ -29,7 +29,7 @@ resource "azurerm_key_vault" "key_vault" {
   }
 
   // extra_tags is on the end to overwrite incorrect tags that already exists.
-  tags = merge(local.default_tags, data.azurerm_resource_group.rg.tags, var.extra_tags)
+  tags = merge(data.azurerm_resource_group.rg.tags, local.default_tags, var.extra_tags)
 
   lifecycle {
     ignore_changes = [


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->

The main goal of this PR is to fix the precedence of merging Azure tags for `key_vault` modules. The following rule should be applied when merging tags

1. Read and inherit tags from the resource groups that contains the resource 
2. Use default tags and replace values for any common tag inherited from resource group
3. Use tags from the parameter `extra_tags`  and replace values for any common tag inherited from resource group or default tags


## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [ ] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [ ] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [X] Bugfix.
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->

- Updated the precedence order for merging Azure tags in the module. The merging strategy was updated from: `default_tags -> resource_group inheritance  ->  extra_tags` to `resource_group inheritance -> default_tags ->  extra_tags`

### How to test it
<!-- Please describe how to test it. -->

Create a new tf file (main.tf for example) at the root of this repo in your working directory and add the code below:

```hcl
terraform {
  required_providers {
    azurerm = {
      source  = "hashicorp/azurerm"
      version = "~> 3.6"
    }

    azurecaf = {
      source  = "aztfmod/azurecaf"
      version = "2.0.0-preview3"
    }
  }

  required_version = "~> 1.3.0"
}

provider "azurerm" {
  
}

module "keyvault" {
  source              = "./azure/key_vault"
  name                = "tfdemo"
  resource_group_name = var.resource_group_name
  external_usage      = true
  environment         = var.environment
  policies            = var.policies
}

variable "resource_group_name" {
  description = "Name of the resource group"
  type        = string
  default     = "rg-nmbrsfabric"
}

variable "environment" {
  description = "Environment type of the apps"
  type        = string
  default     = "dev"
}

variable "policies" {
  description = "(Optional) Access policies created for the Azure Key Vault."
  type = list(object({
    name      = string
    object_id = string
    type      = string
  }))
  default = [
    {
      name      = "sg-mysquad"
      type      = "writers"
      object_id = "985669a9-2569-1af4-922a-8a2acaf5cef1"
    },
  ]
}
```

2. Run the speculative plan. Expected results: The tag `managed_by` should contain the value `terraform` instead of `portal`
```sh
  # module.keyvault.azurerm_key_vault.key_vault will be created
  + resource "azurerm_key_vault" "key_vault" {
      + access_policy                 = (known after apply)
      + id                            = (known after apply)
      + location                      = "westeurope"
      + name                          = (known after apply)
      + public_network_access_enabled = true
      + purge_protection_enabled      = false
      + resource_group_name           = "RG-NmbrsFabric"
      + sku_name                      = "standard"
      + soft_delete_retention_days    = 31
      + tags                          = {
          + "category"    = "microservices_core"
          + "country"     = "global"
          + "created_at"  = "2020-11-11t15:54:57.1433817z"
          + "environment" = "zzzzzz"
          + "managed_by"  = "terraform"
          + "owner"       = "xxxxx"
          + "product"     = "xxxxx"
          + "status"      = "xxxxx"
```

### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
N/A
