### PR TITLE
fix(storage_account): update default tags precedence

### DIFF
--- a/azure/storage_account/main.tf
+++ b/azure/storage_account/main.tf
@@ -21,7 +21,7 @@ resource "azurerm_storage_account" "storage_account" {
   enable_https_traffic_only = true
   min_tls_version           = "TLS1_2"
 
-  tags = merge(local.default_tags, data.azurerm_resource_group.rg.tags, var.extra_tags)
+  tags = merge(data.azurerm_resource_group.rg.tags, local.default_tags, var.extra_tags)  
 
   queue_properties {
     logging {


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->

The main goal of this PR is to fix the precedence of merging Azure tags for `storage_account` modules. The following rule should be applied when merging tags

1. Read and inherit tags from the resource groups that contains the resource 
2. Use default tags and replace values for any common tag inherited from resource group
3. Use tags from the parameter `extra_tags`  and replace values for any common tag inherited from resource group or default tags


## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [ ] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [ ] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [X] Bugfix.
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->

- Updated the precedence order for merging Azure tags in the module. The merging strategy was updated from: `default_tags -> resource_group inheritance  ->  extra_tags` to `resource_group inheritance -> default_tags ->  extra_tags`

### How to test it
<!-- Please describe how to test it. -->

Create a new tf file (main.tf for example) at the root of this repo in your working directory and add the code below:

```hcl
terraform {
  required_providers {
    azurerm = {
      source  = "hashicorp/azurerm"
      version = "~> 3.6"
    }

    azurecaf = {
      source  = "aztfmod/azurecaf"
      version = "2.0.0-preview3"
    }
  }

  required_version = "~> 1.3.0"
}

provider "azurerm" {

}

module "storage" {
  source              = "./azure/storage_account"
  name                = "satfdemoffs"
  environment         = var.environment
  resource_group_name = var.resource_group_name
  account_kind        = "Storage"
  account_tier        = "Standard"
  replication_type    = "LRS"
}


variable "resource_group_name" {
  description = "Name of the resource group"
  type        = string
  default     = "rg-nmbrsfabric"
}

variable "environment" {
  description = "Environment type of the apps"
  type        = string
  default     = "dev"
}
```

2. Run the speculative plan. Expected results: The tag `managed_by` should contain the value `terraform` instead of `portal`
```sh
  # module.storage.azurerm_storage_account.storage_account will be created
  + resource "azurerm_storage_account" "storage_account" {
      + access_tier                       = (known after apply)
      + account_kind                      = "Storage"
      + account_replication_type          = "LRS"
      + account_tier                      = "Standard"
      + allow_nested_items_to_be_public   = true
      + cross_tenant_replication_enabled  = true
      + default_to_oauth_authentication   = false
      + enable_https_traffic_only         = true
      + id                                = (known after apply)
      + infrastructure_encryption_enabled = false
      + is_hns_enabled                    = false
      + large_file_share_enabled          = (known after apply)
      + location                          = "westeurope"
      + min_tls_version                   = "TLS1_2"
      + name                              = (known after apply)
      + nfsv3_enabled                     = false
      + primary_access_key                = (sensitive value)
      + primary_blob_connection_string    = (sensitive value)
      + primary_blob_endpoint             = (known after apply)
      + primary_blob_host                 = (known after apply)
      + primary_connection_string         = (sensitive value)
      + primary_dfs_endpoint              = (known after apply)
      + primary_dfs_host                  = (known after apply)
      + primary_file_endpoint             = (known after apply)
      + primary_file_host                 = (known after apply)
      + primary_location                  = (known after apply)
      + primary_queue_endpoint            = (known after apply)
      + primary_queue_host                = (known after apply)
      + primary_table_endpoint            = (known after apply)
      + primary_table_host                = (known after apply)
      + primary_web_endpoint              = (known after apply)
      + primary_web_host                  = (known after apply)
      + public_network_access_enabled     = true
      + queue_encryption_key_type         = "Service"
      + resource_group_name               = "RG-NmbrsFabric"
      + secondary_access_key              = (sensitive value)
      + secondary_blob_connection_string  = (sensitive value)
      + secondary_blob_endpoint           = (known after apply)
      + secondary_blob_host               = (known after apply)
      + secondary_connection_string       = (sensitive value)
      + secondary_dfs_endpoint            = (known after apply)
      + secondary_dfs_host                = (known after apply)
      + secondary_file_endpoint           = (known after apply)
      + secondary_file_host               = (known after apply)
      + secondary_location                = (known after apply)
      + secondary_queue_endpoint          = (known after apply)
      + secondary_queue_host              = (known after apply)
      + secondary_table_endpoint          = (known after apply)
      + secondary_table_host              = (known after apply)
      + secondary_web_endpoint            = (known after apply)
      + secondary_web_host                = (known after apply)
      + sftp_enabled                      = false
      + shared_access_key_enabled         = true
      + table_encryption_key_type         = "Service"
      + tags                              = {
          + "category"    = "xxxxx"
          + "country"     = "global"
          + "created_at"  = "2019-02-20t15:54:57.1433817z"
          + "environment" = "dev"
          + "managed_by"  = "terraform"
          + "owner"       = "xxxxxx"
          + "product"     = "xxxxxx"
          + "status"      = "xxxxxxx"
        }
```

### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
N/A
