### PR TITLE
fix(resource_group): update default tags precedence

### DIFF
--- a/azure/resource_group/main.tf
+++ b/azure/resource_group/main.tf
@@ -7,7 +7,7 @@ resource "azurecaf_name" "caf_name" {
 resource "azurerm_resource_group" "rg" {
   name     = azurecaf_name.caf_name.result
   location = var.location
-  tags     = merge(var.extra_tags, local.default_tags)
+  tags     = merge(local.default_tags, var.extra_tags)
 
   lifecycle {
     ignore_changes = [


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->

The main goal of this PR is to fix the precedence of merging Azure tags for `resource_group` modules. The following rule should be applied when merging tags

1. Use default tags and replace values for any common tag inherited from resource group
2. Use tags from the parameter `extra_tags`  and replace values for any common tag inherited from default tags


## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [ ] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [ ] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [X] Bugfix.
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->

- Updated the precedence order for merging Azure tags in the module. The merging strategy was updated from: `extra_tags ->  extra_tags` to `default_tags ->  extra_tags`

### How to test it
<!-- Please describe how to test it. -->
N/A

### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
N/A
