### PR TITLE
fix(virtual_network): update tag precedence vnet

### DIFF
--- a/azure/virtual_network/local.tf
+++ b/azure/virtual_network/local.tf
@@ -1,7 +1,8 @@
 locals {
   default_tags = {
-    ProvisionedBy = "Terraform"
+    managed_by = "terraform"
   }
+  
   environment = var.environment
 
   # The exact list of actions needs to be retrieved using the Azure CLI command:

--- a/azure/virtual_network/main.tf
+++ b/azure/virtual_network/main.tf
@@ -9,7 +9,7 @@ resource "azurerm_virtual_network" "vnet" {
   location            = data.azurerm_resource_group.rg.location
   resource_group_name = data.azurerm_resource_group.rg.name
   address_space       = var.address_spaces
-  tags                = merge(local.default_tags, data.azurerm_resource_group.rg.tags, var.extra_tags)
+  tags = merge(data.azurerm_resource_group.rg.tags, local.default_tags, var.extra_tags)
 }
 
 resource "azurerm_subnet" "subnet" {


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->
The main goal of this PR is to fix the precedence of merging Azure tags for `vnet` modules. The following rule should be applied when merging tags

1. Read and inherit tags from the resource groups that contains the resource 
2. Use default tags and replace values for any common tag inherited from resource group
3. Use tags from the parameter `extra_tags`  and replace values for any common tag inherited from resource group or default tags


## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [ ] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [ ] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [X] Bugfix.
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->

- Updated the precedence order for merging Azure tags in the module. The merging strategy was updated from: `default_tags -> resource_group inheritance  ->  extra_tags` to `resource_group inheritance -> default_tags ->  extra_tags`


### How to test it
<!-- Please describe how to test it. -->

Create a new tf file (main.tf for example) at the root of this repo in your working directory and add the code below:

```hcl
terraform {
  required_version = ">= 1.0.0, < 2.0.0"
}
provider "azurerm" {
  features {
  }
}

module "common_network" {
  source              = "./azure/virtual_network"
  resource_group_name = var.resource_group_name
  name                = "vnet-dev-westeu-003"
  address_spaces      = ["10.90.0.0/16"]
  environment         = "dev"
  subnets = [
    {
      name                                           = "orange"
      address_prefixes                               = ["10.90.10.0/16"]
      enforce_private_link_service_network_policies  = false
      enforce_private_link_endpoint_network_policies = false
      service_endpoints                              = ["Microsoft.EventHub", "Microsoft.Web", "Microsoft.Sql"]
      delegations                                    = ["Microsoft.ContainerInstance/containerGroups", "Microsoft.Web/serverFarms", "Microsoft.Databricks/workspaces"]
    },
    {
      name                                           = "apples"
      address_prefixes                               = ["10.90.11.0/16"]
      enforce_private_link_service_network_policies  = false
      enforce_private_link_endpoint_network_policies = false
      service_endpoints                              = ["Microsoft.EventHub"]
      delegations                                    = ["Microsoft.ContainerInstance/containerGroups"]
    },
    {
      name                                           = "lemons"
      address_prefixes                               = ["10.90.12.0/16"]
      enforce_private_link_service_network_policies  = false
      enforce_private_link_endpoint_network_policies = false
      service_endpoints                              = []
      delegations                                    = []
    }
  ]
}

variable "resource_group_name" {
  description = "Name of the resource group"
  type        = string
  default     = "rg-nmbrsfabric"
}
```

2. Run the speculative plan. Expected results: The tag `managed_by` should contain the value `terraform` instead of `portal`
```sh
  + resource "azurerm_virtual_network" "vnet" {
      + address_space       = [
          + "10.90.0.0/16",
        ]
      + dns_servers         = (known after apply)
      + guid                = (known after apply)
      + id                  = (known after apply)
      + location            = "westeurope"
      + name                = "vnet-dev-westeu-003"
      + resource_group_name = "RG-NmbrsFabric"
      + subnet              = (known after apply)
      + tags                = {
          + "category"    = "xxxxxx"
          + "country"     = "global"
          + "created_at"  = "xxxxx"
          + "environment" = "dev"
          + "managed_by"  = "terraform"
          + "owner"       = "xxxx"
          + "product"     = "xxxx"
          + "status"      = "xxxxx"
        }
    }```


### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
N/A