### PR TITLE
refactor(dns_zone): add validation against ICAAN rules

### DIFF
--- a/azure/dns_zone/variables.tf
+++ b/azure/dns_zone/variables.tf
@@ -2,22 +2,49 @@ variable "name" {
   description = "The name of the DNS Zone. Must be a valid domain name."
   type        = string
 
+  # ICAAN rule and limit imposed by Microsoft on Azure Portal 
+  # For more information, see: https://learn.microsoft.com/en-us/azure/dns/private-dns-privatednszone#restrictions
   validation {
-    condition     = length(var.name) >= 2 && length(var.name) <= 34 # Limit found on Azure portal
-    error_message = "The 'name' value is invalid. It must be between 3 and 24 characters."
+    condition     = length(var.name) <= 253
+    error_message = format("Invalid value '%s' for variable 'name'. The DNS zone name must contain no more than 253 characters.", var.name)
   }
 
-  // Accordigly to ICANN Application Guidebook
+  # ICAAN rule and limit imposed by Microsoft on Azure Portal 
+  # For more information, see: https://learn.microsoft.com/en-us/azure/dns/private-dns-privatednszone#restrictions
   validation {
-    condition     = can(regex("(?:\\.[[:alpha:]]{2,6})$", var.name))
-    error_message = "The 'name' value is invalid. The last TLD (Top level domain) must be at least 2 characters long and no more than 6 characters long. It must also contain only letters."
+    condition     = length(split(".", var.name)) >= 2 && length(split(".", var.name)) <= 34 # Limit found on Azure Portal. For more information, see: https://learn.microsoft.com/en-us/azure/dns/private-dns-privatednszone#restrictions
+    error_message = format("Invalid value '%s' for variable 'name'. The DNS zone name must have between 2 and 34 labels. For example, 'contoso.com' has 2 labels.", var.name)
   }
 
+  # ICAAN rule according to ICANN Application Guidebook
   validation {
-    // Full Match Regex For DNS Zone name. It matches 1 or 2 subdomains + Top level domain. Example: 'subdomain1.subdomain2.topleveldomain'. 
-    // Developer's note: Sorry about that big regex. I could not find better solution for that using the RE2 engine.
-    condition     = can(regex("^(?:[[:alnum:]][a-zA-Z0-9-]+[[:alnum:]]\\.){1,2}(?:[[:alpha:]]{2,6})$", var.name))
-    error_message = "The 'name' value is invalid. It must contain no more than 2 subdomains. Only letters, digits, and dashes are allowed in the subdomain name. However, the name must not end or begin with dashes. Valid Examples: 'subomain1.sudomain2.com', 'contoso.co.uk', 'example.com'."
+    condition     = alltrue([for label in split(".", var.name) : length(label) >= 1 && length(label) <= 63])
+    error_message = format("Invalid value '%s' for variable 'name'. Each label must not exceed 63 characters.", var.name)
+  }
+
+  # Validating domain labels according to ICANN Application Guidebook
+  validation {
+    condition     = alltrue([for label in split(".", var.name) : can(regex("^[a-zA-Z0-9](?:[a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?$", label))])
+    error_message = format("Invalid value '%s' for variable 'name'. Each label must consist of letters, numbers, or hyphens, and must not start or end with a hyphen.", var.name)
+  }
+
+  # Validating top level domain (rightmost label of a domain) according to ICANN Application Guidebook
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9](?:[a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])", split(".", var.name)[length(split(".", var.name)) - 1]))
+    error_message = format("Invalid value '%s' for variable 'name'. The TLD (rightmost label of a domain name) each label must consist of letters, numbers, or hyphens, and must not start or end with a hyphen. It must also be between 2 and 63 characters long.", var.name)
+  }
+
+  # Validating top level domains (rightmost label of a domain) against the RFC2606 list of reserved names
+  validation {
+    condition = !contains(
+      [
+        "test",
+        "example",
+        "invalid",
+        "localhost"
+      ], split(".", var.name)[length(split(".", var.name)) - 1]
+    )
+    error_message = format("Invalid value '%s' for variable 'name', The following list of reserved zone names are blocked from creation to prevent disruption of services: 'test', 'example', 'invalid', 'localhost'.", var.name)
   }
 }
 


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->
The main goal of this PR is to apply the same ICAAN rules used in the private DNS zones

## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [X] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [X] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix.
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->
N/A

### How to test it
<!-- Please describe how to test it. -->
N/A

### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
N/A
