### PR TITLE
feat(key_vault): remove provider configs to allow the use of for_each loops

### DIFF
--- a/azure/key_vault/terraform.tf
+++ b/azure/key_vault/terraform.tf
@@ -13,22 +13,3 @@ terraform {
 
   required_version = ">= 1.3.0, < 2.0.0"
 }
-
-provider "azurerm" {
-  features {
-    key_vault {
-      purge_soft_delete_on_destroy               = true
-      purge_soft_deleted_certificates_on_destroy = true
-      purge_soft_deleted_keys_on_destroy         = true
-      purge_soft_deleted_secrets_on_destroy      = true
-
-      # When recovering soft-deleted Key Vault items (Keys, Certificates, and Secrets)
-      # the Principal used by Terraform needs the "recover" permission.
-      recover_soft_deleted_key_vaults   = true
-      recover_soft_deleted_certificates = true
-      recover_soft_deleted_keys         = true
-      recover_soft_deleted_secrets      = true
-
-    }
-  }
-}


### PR DESCRIPTION
The main goal of this pull request is to remove the azurerm provider's configurations from the key_vault module, to allow for the implementation of a JSON-friendly approach. By removing the provider's configuration, it will be possible to create for loops and implement our module in a list of values in the JSON.

## Description
<!--- Please provide a description of your PR -->

## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [X] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [ ] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix.
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->
N/A
### How to test it
<!-- Please describe how to test it. -->
N/A
### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
N/A