### PR TITLE
feature(virtual_network): add subnet name output

### DIFF
--- a/azure/virtual_network/README.md
+++ b/azure/virtual_network/README.md
@@ -7,17 +7,16 @@ the creation of vnet subnets and enables the vnet service delegation, when neede
 
 ## Requirements
 
-| Name                                                                     | Version           |
-| ------------------------------------------------------------------------ | ----------------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 1.3.0, < 2.0.0 |
-| <a name="requirement_azurecaf"></a> [azurecaf](#requirement_azurecaf)    | 2.0.0-preview3    |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement_azurerm)       | ~> 3.6            |
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0, < 2.0.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.6 |
 
 ## Providers
 
-| Name                                                         | Version |
-| ------------------------------------------------------------ | ------- |
-| <a name="provider_azurerm"></a> [azurerm](#provider_azurerm) | 3.6.0   |
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.62.1 |
 
 ## Modules
 
@@ -25,31 +24,31 @@ No modules.
 
 ## Resources
 
-| Name                                                                                                                              | Type        |
-| --------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| [azurerm_subnet.subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet)                   | resource    |
-| [azurerm_virtual_network.vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network)   | resource    |
+| Name | Type |
+|------|------|
+| [azurerm_subnet.subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
+| [azurerm_virtual_network.vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
-| [azurerm_resource_group.rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group)    | data source |
+| [azurerm_resource_group.rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 
 ## Inputs
 
-| Name                                                                                       | Description                                                                          | Type                                                                                                                                                                                                                                                                         | Default | Required |
-| ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | :------: |
-| <a name="input_address_spaces"></a> [address_spaces](#input_address_spaces)                | The address space that is used the virtual network.                                  | `list(string)`                                                                                                                                                                                                                                                               | `[]`    |    no    |
-| <a name="input_environment"></a> [environment](#input_environment)                         | The environment in which the resource should be provisioned.                         | `string`                                                                                                                                                                                                                                                                     | n/a     |   yes    |
-| <a name="input_extra_tags"></a> [extra_tags](#input_extra_tags)                            | (Optional) A extra mapping of tags which should be assigned to the desired resource. | `map(string)`                                                                                                                                                                                                                                                                | `{}`    |    no    |
-| <a name="input_name"></a> [name](#input_name)                                              | The name of the virtual network.                                                     | `string`                                                                                                                                                                                                                                                                     | n/a     |   yes    |
-| <a name="input_resource_group_name"></a> [resource_group_name](#input_resource_group_name) | The name of the resource group in which to create the virtual network.               | `string`                                                                                                                                                                                                                                                                     | n/a     |   yes    |
-| <a name="input_subnets"></a> [subnets](#input_subnets)                                     | List of objects that represent the configuration of each subnet.                     | <pre>list(object({<br> name = string<br> address_prefixes = list(string)<br> delegations = list(string)<br> private_link_service_network_policies_enabled = bool<br> private_endpoint_network_policies_enabled = bool<br> service_endpoints = list(string)<br><br> }))</pre> | `[]`    |    no    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_address_spaces"></a> [address\_spaces](#input\_address\_spaces) | The address space that is used the virtual network. | `list(string)` | `[]` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | The environment in which the resource should be provisioned. | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | The name of the virtual network. | `string` | n/a | yes |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group in which to create the virtual network. | `string` | n/a | yes |
+| <a name="input_subnets"></a> [subnets](#input\_subnets) | List of objects that represent the configuration of each subnet. | <pre>list(object({<br>    name                                          = string<br>    address_prefixes                              = list(string)<br>    delegations                                   = list(string)<br>    private_link_service_network_policies_enabled = bool<br>    private_endpoint_network_policies_enabled     = bool<br>    service_endpoints                             = list(string)<br><br>  }))</pre> | `[]` | no |
 
 ## Outputs
 
-| Name                                                              | Description                                           |
-| ----------------------------------------------------------------- | ----------------------------------------------------- |
-| <a name="output_id"></a> [id](#output_id)                         | Specifies the resource id of the virtual network      |
-| <a name="output_name"></a> [name](#output_name)                   | Specifies the name of the virtual network             |
-| <a name="output_subnet_ids"></a> [subnet_ids](#output_subnet_ids) | Contains a list of the the resource id of the subnets |
+| Name | Description |
+|------|-------------|
+| <a name="output_id"></a> [id](#output\_id) | Specifies the resource id of the virtual network |
+| <a name="output_name"></a> [name](#output\_name) | Specifies the name of the virtual network |
+| <a name="output_subnet_ids"></a> [subnet\_ids](#output\_subnet\_ids) | Contains a list of the the resource id of the subnets |
+| <a name="output_subnets"></a> [subnets](#output\_subnets) | Contains a list of the subnets data |
 
 ## How to use it?
 

--- a/azure/virtual_network/outputs.tf
+++ b/azure/virtual_network/outputs.tf
@@ -8,6 +8,15 @@ output "id" {
   value       = azurerm_virtual_network.vnet.id
 }
 
+output "subnets" {
+  description = "Contains a list of the subnets data"
+  value = [for subnet in azurerm_subnet.subnet : {
+    name = subnet.name
+    id   = subnet.id
+    }
+  ]
+}
+
 output "subnet_ids" {
   description = "Contains a list of the the resource id of the subnets"
   value       = { for subnet in azurerm_subnet.subnet : subnet.name => subnet.id }


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->
The main goal of this PR is to update the outputs of the vnet module to allow the consumption of the subnet name as an output.
## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [X] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [X] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix.
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->
- Added the new output subnets containing a list of subnet's data containing the subnet name and id

### How to test it
<!-- Please describe how to test it. -->
N/A
### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
N/A