### PR TITLE
fix(app_service): update app service naming logic

### DIFF
--- a/azure/app_service/local.tf
+++ b/azure/app_service/local.tf
@@ -23,15 +23,7 @@ locals {
 
   service_plan_name = "asp-${var.service_plan_name}-n${var.node_number}-${var.country}-${var.environment}"
 
-  # Generate names for app services
-  # This naming logic prevents unintentional duplication between the app name and service plan name.
-  # Examples:
-  # 1. When both the plan name and app name are "worker":
-  #    Resulting app service name: "as-worker-<node_number>-<country>-<env>"
-  # 2. When the plan name is "monolith" and the app name is "web":
-  #    Resulting app service name: "as-monolith-web-<node_number>-<country>-<env>"
   app_service_names = [
-    for app_name in var.app_service_names :
-    app_name == var.service_plan_name ? "as-${app_name}-n${var.node_number}-${var.country}-${var.environment}" : "as-${var.service_plan_name}-${app_name}-n${var.node_number}-${var.country}-${var.environment}"
+    for app_name in var.app_service_names : "as-${app_name}-n${var.node_number}-${var.country}-${var.environment}"
   ]
 }

--- a/azure/app_service/variables.tf
+++ b/azure/app_service/variables.tf
@@ -97,7 +97,7 @@ variable "node_number" {
 
   validation {
     condition     = alltrue([try(var.node_number > 0, false), try(var.node_number == floor(var.node_number), false)])
-    error_message = format("Invalid value '%s' for variable 'node_number'. It must be an number and greater than 0.", var.node_number)
+    error_message = format("Invalid value '%s' for variable 'node_number'. It must be an integer number and greater than 0.", var.node_number)
   }
 }
 


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->
The main goal of this PR is to update the naming logic for the app_services, preventing further confusion while composing the app_service name and service_plan_name

## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [X] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [X] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix.
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->
 - Added the `location` parameter to the `virtual_machine` module
### How to test it
<!-- Please describe how to test it. -->

### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
