### PR TITLE
fix(service_bus): update capacity validations for all tiers

### DIFF
--- a/azure/service_bus/main.tf
+++ b/azure/service_bus/main.tf
@@ -14,8 +14,18 @@ resource "azurerm_servicebus_namespace" "service_bus" {
     ignore_changes = [tags]
 
     precondition {
-      condition     = (var.sku_name == "Basic" && var.capacity == 0) || (var.sku_name == "Standard" && var.capacity == 0) || var.sku_name == "Premium"
-      error_message = "The capacity (message unit) must be 0 when using the 'Basic' or 'Standard' SKU."
+      condition     = (var.sku_name == "Basic" && var.capacity == 0) || var.sku_name == "Standard" || var.sku_name == "Premium"
+      error_message = format("Invalid value '%s' for variable 'capacity' (message units) when using the 'Basic' SKU, It must be 0.", var.capacity)
+    }
+
+    precondition {
+      condition     = (var.sku_name == "Standard" && var.capacity == 0) || var.sku_name == "Basic" || var.sku_name == "Premium"
+      error_message = format("Invalid value '%s' for variable 'capacity' (message units) when using the 'Standard' SKU, It must be 0.", var.capacity)
+    }
+
+    precondition {
+      condition     = (var.sku_name == "Premium" && contains([1, 2, 4, 8, 16], var.capacity)) || var.sku_name == "Basic" || var.sku_name == "Standard"
+      error_message = format("Invalid value '%s' for variable 'capacity' (message units) when using the 'Premium' SKU, valid options are 1, 2, 4, 8, 16.", var.capacity)
     }
   }
 }

--- a/azure/service_bus/main.tf
+++ b/azure/service_bus/main.tf
@@ -15,12 +15,12 @@ resource "azurerm_servicebus_namespace" "service_bus" {
 
     precondition {
       condition     = (var.sku_name == "Basic" && var.capacity == 0) || var.sku_name == "Standard" || var.sku_name == "Premium"
-      error_message = format("Invalid value '%s' for variable 'capacity' (message units) when using the 'Basic' SKU, It must be 0.", var.capacity)
+      error_message = format("Invalid value '%s' for variable 'capacity' (message units) when using the 'Basic' SKU, it must be 0.", var.capacity)
     }
 
     precondition {
       condition     = (var.sku_name == "Standard" && var.capacity == 0) || var.sku_name == "Basic" || var.sku_name == "Premium"
-      error_message = format("Invalid value '%s' for variable 'capacity' (message units) when using the 'Standard' SKU, It must be 0.", var.capacity)
+      error_message = format("Invalid value '%s' for variable 'capacity' (message units) when using the 'Standard' SKU, it must be 0.", var.capacity)
     }
 
     precondition {


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->
The main goal of this PR is to fix all validations for the `capacity` parameter for the `service_bus` module. The validations should follow the rules below:
 - For the `Basic` tier, capacity should be 0.
 - For the `Standard` tier, capacity should be 0.
 - Valid options for capacity when using the `Premium` tier are: 1, 2, 4, 8, 16

## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [X] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [ ] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix.
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->
The capacity (message units) is being validated as shown in the rules below
 - For the `Basic` tier, capacity should be 0.
 - For the `Standard` tier, capacity should be 0.
 - Valid options for capacity when using the `Premium` tier are: 1, 2, 4, 8, 16
### How to test it
<!-- Please describe how to test it. -->

### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
