### PR TITLE
feature(nat_gateway): update naming logic

### DIFF
--- a/azure/nat_gateway/README.md
+++ b/azure/nat_gateway/README.md
@@ -38,6 +38,7 @@ No modules.
 | <a name="input_environment"></a> [environment](#input\_environment) | Defines the environment to provision the resources. | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | The location where the resources will be deployed in Azure. For an exaustive list of locations, please use the command 'az account list-locations -o table'. | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | This variable defines the name of the NAT gateway. | `string` | n/a | yes |
+| <a name="input_name_sequence_number"></a> [name\_sequence\_number](#input\_name\_sequence\_number) | A numeric sequence number used for naming the resource. It ensures a unique identifier for each resource instance in the naming convention. | `number` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of an existing Resource Group. | `string` | n/a | yes |
 | <a name="input_subnets"></a> [subnets](#input\_subnets) | Subnets to be included in the NAT gateway | `list(string)` | n/a | yes |
 | <a name="input_vnet_name"></a> [vnet\_name](#input\_vnet\_name) | Name of the Vnet that will be added to the NAT gateway | `string` | n/a | yes |
@@ -58,7 +59,8 @@ A number of code snippets demonstrating different use cases for the module have 
 ```hcl 
 module "nat_gateway" { 
     source                   = "git::github.com/Nmbrs/tf-modules//azure/nat_gateway"
-    name                     = "public"
+    name                     = "myapp"
+    name_sequence_number     = 1
     vnet_resource_group_name = "rg-myrg-dev"
     vnet_name                = "vnet-westeu-001-dev"
     subnets                  = ["default","internal"]

--- a/azure/nat_gateway/local.tf
+++ b/azure/nat_gateway/local.tf
@@ -1,0 +1,5 @@
+locals {
+  nat_gateway_name = "ng-${var.name}-${var.environment}-${var.location}-${format("%03d", var.name_sequence_number)}"
+
+  public_ip_name = "pip-${var.name}-${var.environment}-${var.location}-${format("%03d", var.name_sequence_number)}"
+}

--- a/azure/nat_gateway/main.tf
+++ b/azure/nat_gateway/main.tf
@@ -6,7 +6,7 @@ data "azurerm_subnet" "vnet" {
 }
 
 resource "azurerm_public_ip" "natgw" {
-  name                = "pip-ngw-${var.name}-${var.environment}-ip"
+  name                = local.public_ip_name
   location            = var.location
   resource_group_name = var.resource_group_name
   allocation_method   = "Static"
@@ -19,7 +19,7 @@ resource "azurerm_public_ip" "natgw" {
 }
 
 resource "azurerm_nat_gateway" "natgw" {
-  name                    = "ngw-${var.name}-${var.environment}"
+  name                    = local.nat_gateway_name
   location                = var.location
   resource_group_name     = var.resource_group_name
   sku_name                = "Standard"

--- a/azure/nat_gateway/variables.tf
+++ b/azure/nat_gateway/variables.tf
@@ -32,3 +32,13 @@ variable "subnets" {
   type        = list(string)
   description = "Subnets to be included in the NAT gateway"
 }
+
+variable "name_sequence_number" {
+  type        = number
+  description = "A numeric sequence number used for naming the resource. It ensures a unique identifier for each resource instance in the naming convention."
+
+  validation {
+    condition     = var.name_sequence_number >= 1 && var.name_sequence_number <= 999
+    error_message = format("Invalid value '%s' for variable 'name'. It must be between 1 and 999.", var.name_sequence_number)
+  }
+}


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->
The main goal of this PR is to update the naming logic for the nat_gateway, enabling it to comply with the following rule:
- nat gateway: `ng-<application/workload><location><environment><###>`
- public ip: `pip-ng-<application/workload><location><environment><###>`

## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [X] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [X] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix.
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->
 - Added the `naming_sequential_number` parameter
### How to test it
<!-- Please describe how to test it. -->
N/A
### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
