### PR TITLE
feature(service_bus): replace name parameter in favor of workload

### DIFF
--- a/azure/service_bus/README.md
+++ b/azure/service_bus/README.md
@@ -37,7 +37,7 @@ No modules.
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of an existing Resource Group. | `string` | n/a | yes |
 | <a name="input_sku_name"></a> [sku\_name](#input\_sku\_name) | Configuration of the size and capacity of the service bus. | `string` | n/a | yes |
 | <a name="input_workload"></a> [workload](#input\_workload) | The workload name of the service bus namespace. | `string` | n/a | yes |
-| <a name="input_zone_redundant"></a> [zone\_redundant](#input\_zone\_redundant) | Defines whether or not this resource is zone redundant. The required sku to enable it needs to be 'Premium'. | `bool` | `false` | no |
+| <a name="input_zone_redundant"></a> [zone\_redundant](#input\_zone\_redundant) | Defines whether or not this resource is zone redundant. The required sku to enable it needs to be 'Premium'. | `bool` | `true` | no |
 
 ## Outputs
 
@@ -46,6 +46,7 @@ No modules.
 | <a name="output_default_connection_string"></a> [default\_connection\_string](#output\_default\_connection\_string) | The primary connection string for the authorization rule RootManageSharedAccessKey which is created automatically by Azure. |
 | <a name="output_id"></a> [id](#output\_id) | The servicebus namespace ID. |
 | <a name="output_name"></a> [name](#output\_name) | The servicebus namespace name. |
+| <a name="output_workload"></a> [workload](#output\_workload) | The servicebus namespace workload name. |
 
 ## How to use it?
 
@@ -57,7 +58,7 @@ A number of code snippets demonstrating different use cases for the module have 
 module "service_bus" {
   source = "git::github.com/Nmbrs/tf-modules//azure/service_bus"
 
-  name                = "test"
+  workload            = "test"
   environment         = "dev"
   location            = "westeurope"
   resource_group_name = "rg-service-bus"

--- a/azure/service_bus/local.tf
+++ b/azure/service_bus/local.tf
@@ -1,0 +1,3 @@
+locals {
+  service_bus_name = lower("sb-nmbrs-${var.workload}-${var.environment}")
+}

--- a/azure/service_bus/main.tf
+++ b/azure/service_bus/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_servicebus_namespace" "service_bus" {
-  name                = "sb-${var.workload}-${var.environment}"
+  name                = "sb-nmbrs-${var.workload}-${var.environment}"
   location            = var.location
   resource_group_name = var.resource_group_name
   sku                 = var.sku_name

--- a/azure/service_bus/output.tf
+++ b/azure/service_bus/output.tf
@@ -3,6 +3,11 @@ output "name" {
   description = "The servicebus namespace name."
 }
 
+output "workload" {
+  description = "The servicebus namespace workload name."
+  value       = var.workload
+}
+
 output "id" {
   value       = azurerm_servicebus_namespace.service_bus.id
   description = "The servicebus namespace ID."


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->
The main goal of this PR is to update `service_bus` naming logic, replacing the parameter `name` in favor of the `workload`

## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [X] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [ ] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix.
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->

### How to test it
<!-- Please describe how to test it. -->

### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
