### PR TITLE
feature(application_insights): replace name parameter in favor of workload

### DIFF
--- a/azure/application_insights/README.md
+++ b/azure/application_insights/README.md
@@ -35,10 +35,10 @@ No modules.
 | <a name="input_application_type"></a> [application\_type](#input\_application\_type) | Specifies the retention period in days. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment in which the resource should be provisioned. | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | The location where the resources will be deployed in Azure. For an exaustive list of locations, please use the command 'az account list-locations -o table'. | `string` | n/a | yes |
-| <a name="input_name"></a> [name](#input\_name) | The workload name of the app insights component. | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of an existing Resource Group. | `string` | n/a | yes |
 | <a name="input_retention_in_days"></a> [retention\_in\_days](#input\_retention\_in\_days) | Specifies the retention period in days. | `number` | `90` | no |
 | <a name="input_sku_name"></a> [sku\_name](#input\_sku\_name) | Configuration of the size and capacity of the logspace analytics. | `string` | n/a | yes |
+| <a name="input_workload"></a> [workload](#input\_workload) | The workload name of the app insights component. | `string` | n/a | yes |
 | <a name="input_workspace_name"></a> [workspace\_name](#input\_workspace\_name) | Name of the log analytics workspace that will be added to the NAT gateway | `string` | n/a | yes |
 | <a name="input_workspace_resource_group_name"></a> [workspace\_resource\_group\_name](#input\_workspace\_resource\_group\_name) | Resource group of the log analytics workspace that will be added to the NAT gateway | `string` | n/a | yes |
 
@@ -51,19 +51,20 @@ No modules.
 | <a name="output_id"></a> [id](#output\_id) | The ID of the Application Insights component. |
 | <a name="output_instrumentation_key"></a> [instrumentation\_key](#output\_instrumentation\_key) | The Instrumentation Key for this Application Insights component. |
 | <a name="output_name"></a> [name](#output\_name) | The Application Insight component name. |
+| <a name="output_workload"></a> [workload](#output\_workload) | The Application Insights workload name. |
 
 ## How to use it?
 
 A number of code snippets demonstrating different use cases for the module have been included to help you understand how to use the module in Terraform.
 
-## Virtual Gateway
+## Application Insights
 
 ```hcl
   module "app_insights" {
   source                        = "./azure/application_insights"
   workspace_name                = "rg-myworkspace-dev"
   workspace_resource_group_name = "myworkspace"
-  name                          = "myapp-n1-nl"
+  workload                      = "myapp-n1-nl"
   application_type              = "web"
   resource_group_name           = "rg-myapp-dev"
   environment                   = "dev"

--- a/azure/application_insights/local.tf
+++ b/azure/application_insights/local.tf
@@ -1,3 +1,3 @@
 locals {
-  app_insights_name = "appi-${var.name}-${var.environment}"
+  app_insights_name = "appi-${var.workload}-${var.environment}"
 }

--- a/azure/application_insights/output.tf
+++ b/azure/application_insights/output.tf
@@ -3,6 +3,11 @@ output "name" {
   description = "The Application Insight component name."
 }
 
+output "workload" {
+  description = "The Application Insights workload name."
+  value       = var.workload
+}
+
 output "id" {
   value       = azurerm_application_insights.insights.app_id
   description = "The ID of the Application Insights component."

--- a/azure/application_insights/variables.tf
+++ b/azure/application_insights/variables.tf
@@ -3,7 +3,7 @@ variable "resource_group_name" {
   description = "The name of an existing Resource Group."
 }
 
-variable "name" {
+variable "workload" {
   description = "The workload name of the app insights component."
   type        = string
 }


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->
The main goal of this PR is to update `application_insights` naming logic, replacing the parameter `name` in favor of the `workload`

## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [X] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [ ] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix.
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->

### How to test it
<!-- Please describe how to test it. -->

### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
