### PR TITLE
feature(redis_cache): replace name parameter in favor of workload

### DIFF
--- a/azure/redis_cache/README.md
+++ b/azure/redis_cache/README.md
@@ -34,24 +34,25 @@ No modules.
 | <a name="input_cache_size_in_gb"></a> [cache\_size\_in\_gb](#input\_cache\_size\_in\_gb) | The size of the Redis cache per instance in gigabytes (GB) | `number` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment in which the resource should be provisioned. | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | The location where the resources will be deployed in Azure. For an exaustive list of locations, please use the command 'az account list-locations -o table'. | `string` | n/a | yes |
-| <a name="input_name"></a> [name](#input\_name) | Name of the  Redis instance. It must follow the CAF naming convention. | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of an existing Resource Group. | `string` | n/a | yes |
 | <a name="input_shard_count"></a> [shard\_count](#input\_shard\_count) | The number of shards for the Redis cluster. | `number` | `0` | no |
 | <a name="input_sku_name"></a> [sku\_name](#input\_sku\_name) | Configuration of the size and capacity of the redis cache. | `string` | n/a | yes |
+| <a name="input_workload"></a> [workload](#input\_workload) | The workload name of the redis instance. | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | <a name="output_hostname"></a> [hostname](#output\_hostname) | The Hostname of the Redis Instance. |
-| <a name="output_id"></a> [id](#output\_id) | Redis ID. |
+| <a name="output_id"></a> [id](#output\_id) | The Redis ID. |
 | <a name="output_name"></a> [name](#output\_name) | The name of the Redis Instance. |
 | <a name="output_non_ssl_port"></a> [non\_ssl\_port](#output\_non\_ssl\_port) | The non-SSL Port of the Redis Instance. |
 | <a name="output_primary_access_key"></a> [primary\_access\_key](#output\_primary\_access\_key) | The primary access key for  the Redis Instance. |
 | <a name="output_primary_connection_string"></a> [primary\_connection\_string](#output\_primary\_connection\_string) | The primary connection string of the Redis Instance. |
 | <a name="output_secondary_access_key"></a> [secondary\_access\_key](#output\_secondary\_access\_key) | The secondary access key for  the Redis Instance. |
 | <a name="output_secondary_connection_string"></a> [secondary\_connection\_string](#output\_secondary\_connection\_string) | The primary connection string of the Redis Instance. |
-| <a name="output_ssl_port"></a> [ssl\_port](#output\_ssl\_port) | ssl\_port - The SSL Port of the Redis Instance. |
+| <a name="output_ssl_port"></a> [ssl\_port](#output\_ssl\_port) | The SSL Port of the Redis Instance. |
+| <a name="output_workload"></a> [workload](#output\_workload) | The redis instance workload name. |
 
 ## How to use it?
 
@@ -74,7 +75,7 @@ module "redis_cache" {
 ```hcl
 module "redis_cache" {
   source              = "git::github.com/Nmbrs/tf-modules//azure/redis_cache"
-  name                = "my-redis-cache"
+  workload                = "my-redis-cache"
   resource_group_name = "rg-my-resource-group"
   environment         = "dev"
   location            = "westeurope"
@@ -88,7 +89,7 @@ module "redis_cache" {
 ```hcl
 module "redis_cache" {
   source              = "git::github.com/Nmbrs/tf-modules//azure/redis_cache"
-  name                = "my-redis-cache"
+  workload                = "my-redis-cache"
   resource_group_name = "rg-my-resource-group"
   environment         = "dev"
   location            = "westeurope"
@@ -101,7 +102,7 @@ module "redis_cache" {
 ```hcl
 module "redis_cache" {
   source              = "git::github.com/Nmbrs/tf-modules//azure/redis_cache"
-  name                = "my-redis-cache"
+  workload                = "my-redis-cache"
   resource_group_name = "rg-my-resource-group"
   environment         = "dev"
   location            = "westeurope"

--- a/azure/redis_cache/local.tf
+++ b/azure/redis_cache/local.tf
@@ -1,4 +1,5 @@
 locals {
+  redis_cache_name = lower("redis-${var.workload}-${var.environment}")
   # cache size translated into premium tier capacity
   premium_tier_capacity = {
     6   = 1

--- a/azure/redis_cache/main.tf
+++ b/azure/redis_cache/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_redis_cache" "redis" {
-  name                          = "redis-${var.name}-${var.environment}"
+  name                          = local.redis_cache_name
   location                      = var.location
   resource_group_name           = var.resource_group_name
   capacity                      = var.sku_name == "Premium" ? local.premium_tier_capacity[var.cache_size_in_gb] : local.basic_standard_tier_capacity[var.cache_size_in_gb]
@@ -34,7 +34,7 @@ resource "azurerm_redis_cache" "redis" {
   lifecycle {
     ignore_changes = [tags]
 
-    ## cache_size_in_gb validation 
+    ## cache_size_in_gb validation
     precondition {
       condition     = (var.sku_name == "Basic" && contains([0.25, 1, 2.5, 6, 13, 26, 53], var.cache_size_in_gb)) || var.sku_name == "Standard" || var.sku_name == "Premium"
       error_message = format("Invalid value '%s' for variable 'cache_size_in_gb' when using the 'Basic' SKU, valid options are 0.25, 1, 2.5, 6, 13, 26, 53.", var.cache_size_in_gb)

--- a/azure/redis_cache/outputs.tf
+++ b/azure/redis_cache/outputs.tf
@@ -1,11 +1,16 @@
-output "id" {
-  description = "Redis ID."
-  value       = azurerm_redis_cache.redis.id
-}
-
 output "name" {
   description = "The name of the Redis Instance."
   value       = azurerm_redis_cache.redis.name
+}
+
+output "workload" {
+  description = "The redis instance workload name."
+  value       = var.workload
+}
+
+output "id" {
+  description = "The Redis ID."
+  value       = azurerm_redis_cache.redis.id
 }
 
 output "hostname" {
@@ -14,7 +19,7 @@ output "hostname" {
 }
 
 output "ssl_port" {
-  description = "ssl_port - The SSL Port of the Redis Instance."
+  description = "The SSL Port of the Redis Instance."
   value       = azurerm_redis_cache.redis.ssl_port
 }
 

--- a/azure/redis_cache/variables.tf
+++ b/azure/redis_cache/variables.tf
@@ -3,8 +3,8 @@ variable "resource_group_name" {
   description = "The name of an existing Resource Group."
 }
 
-variable "name" {
-  description = "Name of the  Redis instance. It must follow the CAF naming convention."
+variable "workload" {
+  description = "The workload name of the redis instance."
   type        = string
 
   validation {


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->
The main goal of this PR is to update `redis_cache` naming logic, replacing the parameter `name` in favor of the `workload`

## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [X] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [ ] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix.
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->

### How to test it
<!-- Please describe how to test it. -->

### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
