### PR TITLE
feature(key_vault): enable purge protection by default

### DIFF
--- a/azure/key_vault/README.md
+++ b/azure/key_vault/README.md
@@ -47,7 +47,6 @@ No modules.
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment in which the resource should be provisioned. | `string` | n/a | yes |
 | <a name="input_external_usage"></a> [external\_usage](#input\_external\_usage) | (Optional) Specifies whether the keyvault should be used internally or externally. | `bool` | `true` | no |
 | <a name="input_location"></a> [location](#input\_location) | The location where the resources will be deployed in Azure. For an exaustive list of locations, please use the command 'az account list-locations -o table'. | `string` | n/a | yes |
-| <a name="input_protection_enabled"></a> [protection\_enabled](#input\_protection\_enabled) | (Optional) Enables the keyvault purge protection in case of accidental deletion. Default is false. | `bool` | `false` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of an existing Resource Group. | `string` | n/a | yes |
 | <a name="input_workload"></a> [workload](#input\_workload) | The workload name of the key vault. | `string` | n/a | yes |
 

--- a/azure/key_vault/main.tf
+++ b/azure/key_vault/main.tf
@@ -8,9 +8,8 @@ resource "azurerm_key_vault" "key_vault" {
   tenant_id                  = data.azurerm_client_config.current.tenant_id
   sku_name                   = "standard"
   soft_delete_retention_days = 31
-  #tfsec:ignore:azure-keyvault-no-purge
-  purge_protection_enabled  = var.protection_enabled
-  enable_rbac_authorization = var.enable_rbac_authorization
+  purge_protection_enabled   = true
+  enable_rbac_authorization  = var.enable_rbac_authorization
 
   network_acls {
     #tfsec:ignore:azure-keyvault-specify-network-acl

--- a/azure/key_vault/variables.tf
+++ b/azure/key_vault/variables.tf
@@ -29,12 +29,6 @@ variable "external_usage" {
   default     = true
 }
 
-variable "protection_enabled" {
-  description = "(Optional) Enables the keyvault purge protection in case of accidental deletion. Default is false."
-  type        = bool
-  default     = false
-}
-
 variable "access_policies" {
   description = "(Optional) Access policies created for the Azure Key Vault."
   type = list(object({


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->

The main goal of this PR is to enable purge protection by default in the key vaults

## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [X] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [ ] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix.
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->
- Purge protection is enabled by default in the key vault
### How to test it
<!-- Please describe how to test it. -->
N/A
### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
N/A