### PR TITLE
feature(virtual_network_peering): remove peering prefix from resource naming

### DIFF
--- a/azure/virtual_network_peering/local.tf
+++ b/azure/virtual_network_peering/local.tf
@@ -1,0 +1,4 @@
+locals {
+  source_peering_name      = "${var.vnet_source.name}-to-${var.vnet_destination.name}"
+  destination_peering_name = "${var.vnet_destination.name}-to-${var.vnet_source.name}"
+}

--- a/azure/virtual_network_peering/main.tf
+++ b/azure/virtual_network_peering/main.tf
@@ -9,7 +9,7 @@ data "azurerm_virtual_network" "vnet_destination" {
 }
 
 resource "azurerm_virtual_network_peering" "vnet_source" {
-  name                         = "peering-${var.vnet_source.name}-to-${var.vnet_destination.name}"
+  name                         = local.source_peering_name
   virtual_network_name         = var.vnet_source.name
   resource_group_name          = var.vnet_source.resource_group_name
   remote_virtual_network_id    = data.azurerm_virtual_network.vnet_destination.id
@@ -20,7 +20,7 @@ resource "azurerm_virtual_network_peering" "vnet_source" {
 }
 
 resource "azurerm_virtual_network_peering" "vnet_destnation" {
-  name                         = "peering-${var.vnet_destination.name}-to-${var.vnet_source.name}"
+  name                         = local.destination_peering_name
   virtual_network_name         = var.vnet_destination.name
   resource_group_name          = var.vnet_destination.resource_group_name
   remote_virtual_network_id    = data.azurerm_virtual_network.vnet_source.id


### PR DESCRIPTION
The main goal of this PR is to remove the `peering` prefix of the resource to accommodate bigger vnet names

## Description
<!--- Please provide a description of your PR -->

## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [X] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [ ] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix.
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->

### How to test it
<!-- Please describe how to test it. -->

### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
