### PR TITLE
feature(storage_account): update https only parameter

### DIFF
--- a/azure/storage_account/README.md
+++ b/azure/storage_account/README.md
@@ -15,7 +15,7 @@ The `storage_account` module is an abstraction that implements all the necessary
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.82.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.70 |
 
 ## Modules
 

--- a/azure/storage_account/main.tf
+++ b/azure/storage_account/main.tf
@@ -1,12 +1,12 @@
 resource "azurerm_storage_account" "storage_account" {
-  name                      = local.storage_account_name
-  resource_group_name       = var.resource_group_name
-  location                  = var.location
-  account_kind              = var.account_kind
-  account_tier              = var.account_tier
-  account_replication_type  = var.replication_type
-  enable_https_traffic_only = true
-  min_tls_version           = "TLS1_2"
+  name                       = local.storage_account_name
+  resource_group_name        = var.resource_group_name
+  location                   = var.location
+  account_kind               = var.account_kind
+  account_tier               = var.account_tier
+  account_replication_type   = var.replication_type
+  https_traffic_only_enabled = true
+  min_tls_version            = "TLS1_2"
 
   lifecycle {
     ignore_changes = [tags]

--- a/azure/storage_account/terraform.tf
+++ b/azure/storage_account/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.70"
+      version = "~> 3.116"
     }
   }
 


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->

The main goal of this PR is to update the parameter `enable_https_traffic_only` to ` https_traffic_only_enabled` as it was deprecated by the `azurerm`  provider v4.x


## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [X] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [ ] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix.
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->

No changes

### How to test it
<!-- Please describe how to test it. -->

Create a new tf file (main.tf for example) at the root of this repo in your working directory and add the code below:

```hcl
terraform {
  required_providers {
    azurerm = {
      source  = "hashicorp/azurerm"
      version = "~> 3.116"
    }

  }

  required_version = "~> 1.5.0"
}

provider "azurerm" {

}

module "storage" {
  source              = "./azure/storage_account"
  name                = "satfdemo"
  environment         = var.environment
  resource_group_name = var.resource_group_name
  account_kind        = "Storage"
  account_tier        = "Standard"
  replication_type    = "LRS"
}


variable "resource_group_name" {
  description = "Name of the resource group"
  type        = string
  default     = "rg-demo
}

variable "environment" {
  description = "Environment type of the apps"
  type        = string
  default     = "dev"
}
```

2. Apply the configuration and the new storage account should keep accepting only https connections
```

### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
N/A
