### PR TITLE
feature(azuredevops_project): add multiple ownerships

### DIFF
--- a/azuredevops/project/README.md
+++ b/azuredevops/project/README.md
@@ -1,3 +1,4 @@
+<!-- BEGIN_TF_DOCS -->
 # Azure Dev Ops Project Module
 
 ## Sumary
@@ -10,13 +11,14 @@ the creation of vnet subnets and enables the vnet service delegation, when neede
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0, < 2.0.0 |
-| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | ~> 1.3.0 |
+| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | ~> 1.6 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.117 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuredevops"></a> [azuredevops](#provider\_azuredevops) | ~> 1.3.0 |
+| <a name="provider_azuredevops"></a> [azuredevops](#provider\_azuredevops) | ~> 1.6 |
 
 ## Modules
 
@@ -28,10 +30,12 @@ No modules.
 |------|------|
 | [azuredevops_check_approval.prod_environment](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/check_approval) | resource |
 | [azuredevops_check_approval.sand_environment](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/check_approval) | resource |
+| [azuredevops_check_approval.stage_environment](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/check_approval) | resource |
 | [azuredevops_check_approval.test_environment](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/check_approval) | resource |
 | [azuredevops_environment.dev](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/environment) | resource |
 | [azuredevops_environment.prod](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/environment) | resource |
 | [azuredevops_environment.sand](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/environment) | resource |
+| [azuredevops_environment.stage](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/environment) | resource |
 | [azuredevops_environment.test](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/environment) | resource |
 | [azuredevops_group_membership.project_administrators](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/group_membership) | resource |
 | [azuredevops_group_membership.project_default_team_membership](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/group_membership) | resource |
@@ -49,10 +53,10 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_group_administrators"></a> [group\_administrators](#input\_group\_administrators) | Group that will be the administrator at the Azure DevOps project | `string` | n/a | yes |
-| <a name="input_group_contributors"></a> [group\_contributors](#input\_group\_contributors) | Group that will be the contributor at the Azure DevOps project | `string` | n/a | yes |
-| <a name="input_group_readers"></a> [group\_readers](#input\_group\_readers) | Group that will be the readers at the Azure DevOps project | `string` | n/a | yes |
+| <a name="input_administrators_groups"></a> [administrators\_groups](#input\_administrators\_groups) | List of groups that will be administrators at the Azure DevOps project | `list(string)` | n/a | yes |
+| <a name="input_contributors_groups"></a> [contributors\_groups](#input\_contributors\_groups) | List of groups that will be contributors at the Azure DevOps project | `list(string)` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | The name of the Azure Dev Ops project | `string` | n/a | yes |
+| <a name="input_readers_groups"></a> [readers\_groups](#input\_readers\_groups) | List of groups that will be readers at the Azure DevOps project | `list(string)` | n/a | yes |
 
 ## Outputs
 
@@ -66,8 +70,9 @@ A number of code snippets demonstrating different use cases for the module have 
 module "azuredevops_project" {
   source                = "git::github.com/Nmbrs/tf-modules//azuredevops/project"
   name                  = "internaltools"
-  group_owners          = "sg-owners"
-  group_administrators  = "sg-domain-infra
-  group_readers         = "sg-developers
+  group_owners          = ["sg-owners"]
+  group_administrators  = ["sg-domain-admin]
+  group_readers         = ["sg-all-developers"]
 }
 ```
+<!-- END_TF_DOCS -->

--- a/azuredevops/project/README.md
+++ b/azuredevops/project/README.md
@@ -3,8 +3,7 @@
 
 ## Sumary
 
-The `virtual_network` module supports the creation of Microsoft Azure virtual network in an existent Azure resource group name. This module also supports
-the creation of vnet subnets and enables the vnet service delegation, when needed.
+The `azuredevops_project` module simplifies the creation and configuration of Azure DevOps projects. It enables the setup of core project settings, such as repositories, pipelines, and service connections, while integrating with existing Azure DevOps organizations.
 
 ## Requirements
 

--- a/azuredevops/project/data.tf
+++ b/azuredevops/project/data.tf
@@ -1,16 +1,16 @@
 
 data "azuredevops_group" "aad_administrators" {
-  for_each = toset([for group in var.administrators_groups: lower(group)])
+  for_each = toset([for group in var.administrators_groups : lower(group)])
   name     = each.value
 }
 
 data "azuredevops_group" "aad_contributors" {
-  for_each = toset([for group in var.contributors_groups: lower(group)])
+  for_each = toset([for group in var.contributors_groups : lower(group)])
   name     = each.value
 }
 
 data "azuredevops_group" "aad_readers" {
-  for_each = toset([for group in var.readers_groups: lower(group)])
+  for_each = toset([for group in var.readers_groups : lower(group)])
   name     = each.value
 }
 

--- a/azuredevops/project/data.tf
+++ b/azuredevops/project/data.tf
@@ -1,16 +1,16 @@
 
 data "azuredevops_group" "aad_administrators" {
-  for_each = toset(lower(var.administrators_groups))
+  for_each = toset([for group in var.administrators_groups: lower(group)])
   name     = each.value
 }
 
 data "azuredevops_group" "aad_contributors" {
-  for_each = toset(lower(var.contributors_groups))
+  for_each = toset([for group in var.contributors_groups: lower(group)])
   name     = each.value
 }
 
 data "azuredevops_group" "aad_readers" {
-  for_each = toset(lower(var.readers_groups))
+  for_each = toset([for group in var.readers_groups: lower(group)])
   name     = each.value
 }
 

--- a/azuredevops/project/data.tf
+++ b/azuredevops/project/data.tf
@@ -1,14 +1,17 @@
 
 data "azuredevops_group" "aad_administrators" {
-  name = lower(var.administrators_groups[0])
+  for_each = toset(lower(var.administrators_groups))
+  name     = each.value
 }
 
 data "azuredevops_group" "aad_contributors" {
-  name = lower(var.contributors_groups[0])
+  for_each = toset(lower(var.contributors_groups))
+  name     = each.value
 }
 
 data "azuredevops_group" "aad_readers" {
-  name = lower(var.readers_groups[0])
+  for_each = toset(lower(var.readers_groups))
+  name     = each.value
 }
 
 data "azuredevops_group" "contributors" {

--- a/azuredevops/project/data.tf
+++ b/azuredevops/project/data.tf
@@ -1,14 +1,14 @@
 
 data "azuredevops_group" "aad_administrators" {
-  name = lower(var.group_administrators)
+  name = lower(var.administrators_groups[0])
 }
 
 data "azuredevops_group" "aad_contributors" {
-  name = lower(var.group_contributors)
+  name = lower(var.contributors_groups[0])
 }
 
 data "azuredevops_group" "aad_readers" {
-  name = lower(var.group_readers)
+  name = lower(var.readers_groups[0])
 }
 
 data "azuredevops_group" "contributors" {

--- a/azuredevops/project/main.tf
+++ b/azuredevops/project/main.tf
@@ -113,7 +113,7 @@ resource "azuredevops_group_membership" "project_default_team_membership" {
   group = data.azuredevops_group.project_default_team.descriptor
   mode  = "add"
   members = [
-    for group in data.azuredevops_group.aad_contributors : group.value.descriptor
+    for group in data.azuredevops_group.aad_contributors : group.descriptor
   ]
 }
 
@@ -121,7 +121,7 @@ resource "azuredevops_group_membership" "project_administrators" {
   group = data.azuredevops_group.project_administrators.descriptor
   mode  = "add"
   members = [
-    for group in data.azuredevops_group.aad_administrators : group.value.descriptor
+    for group in data.azuredevops_group.aad_administrators : group.descriptor
   ]
 }
 
@@ -129,7 +129,7 @@ resource "azuredevops_group_membership" "readers" {
   group = data.azuredevops_group.readers.descriptor
   mode  = "add"
   members = [
-    for group in data.azuredevops_group.aad_readers : group.value.descriptor
+    for group in data.azuredevops_group.aad_readers : group.descriptor
   ]
 }
 

--- a/azuredevops/project/main.tf
+++ b/azuredevops/project/main.tf
@@ -113,7 +113,7 @@ resource "azuredevops_group_membership" "project_default_team_membership" {
   group = data.azuredevops_group.project_default_team.descriptor
   mode  = "add"
   members = [
-    data.azuredevops_group.aad_contributors.descriptor
+    for group in data.azuredevops_group.aad_contributors : group.value.descriptor
   ]
 }
 
@@ -121,7 +121,7 @@ resource "azuredevops_group_membership" "project_administrators" {
   group = data.azuredevops_group.project_administrators.descriptor
   mode  = "add"
   members = [
-    data.azuredevops_group.aad_administrators.descriptor
+    for group in data.azuredevops_group.aad_administrators : group.value.descriptor
   ]
 }
 
@@ -129,6 +129,23 @@ resource "azuredevops_group_membership" "readers" {
   group = data.azuredevops_group.readers.descriptor
   mode  = "add"
   members = [
-    data.azuredevops_group.aad_readers.descriptor
+    for group in data.azuredevops_group.aad_readers : group.value.descriptor
   ]
 }
+
+# # ==============================================================================
+# # Azure DevOps Azure Service Connections  - Workload Identity Federation
+# # ==============================================================================
+# resource "azuredevops_serviceendpoint_azurerm" "azure_connection" {
+#   for_each                               = { for azure_connection in var.service_connections.azure : azure_connection.name => azure_connection }
+#   project_id                             = azuredevops_project.project.id
+#   service_endpoint_name                  = each.value.name
+#   description                            = "Azure Service conncetion managed by Terraform"
+#   service_endpoint_authentication_scheme = "WorkloadIdentityFederation"
+#   credentials {
+#     serviceprincipalid = data.azurerm_user_assigned_identity[each.key].managed_identity.id
+#   }
+#   azurerm_spn_tenantid      = data.azurerm_subscription.current.tenant_id
+#   azurerm_subscription_id   = data.azurerm_subscription.current.id
+#   azurerm_subscription_name = data.azurerm_subscription.current.display_name
+# }

--- a/azuredevops/project/main.tf
+++ b/azuredevops/project/main.tf
@@ -87,6 +87,25 @@ resource "azuredevops_check_approval" "sand_environment" {
   timeout = (24 * 60) * 14 #in minutes
 }
 
+# stage
+resource "azuredevops_environment" "stage" {
+  project_id = azuredevops_project.project.id
+  name       = "stage"
+}
+
+resource "azuredevops_check_approval" "stage_environment" {
+  project_id           = azuredevops_project.project.id
+  target_resource_id   = azuredevops_environment.stage.id
+  target_resource_type = "environment"
+
+  requester_can_approve      = true
+  minimum_required_approvers = 1
+  approvers = [
+    data.azuredevops_group.project_default_team.origin_id
+  ]
+  timeout = (24 * 60) * 14 #in minutes
+}
+
 # ==============================================================================
 # Azure DevOps Project - Group Memberships
 # ==============================================================================

--- a/azuredevops/project/terraform.tf
+++ b/azuredevops/project/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azuredevops = {
       source  = "microsoft/azuredevops"
-      version = "~> 1.4.0"
+      version = "~> 1.4"
     }
 
     azurerm = {

--- a/azuredevops/project/terraform.tf
+++ b/azuredevops/project/terraform.tf
@@ -2,7 +2,12 @@ terraform {
   required_providers {
     azuredevops = {
       source  = "microsoft/azuredevops"
-      version = "~> 1.3.0"
+      version = "~> 1.4.0"
+    }
+
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.100"
     }
   }
 

--- a/azuredevops/project/terraform.tf
+++ b/azuredevops/project/terraform.tf
@@ -2,12 +2,12 @@ terraform {
   required_providers {
     azuredevops = {
       source  = "microsoft/azuredevops"
-      version = "~> 1.4"
+      version = "~> 1.6"
     }
 
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.100"
+      version = "~> 3.117"
     }
   }
 

--- a/azuredevops/project/variables.tf
+++ b/azuredevops/project/variables.tf
@@ -28,17 +28,27 @@ variable "name" {
   }
 }
 
-variable "group_contributors" {
-  description = "Group that will be the contributor at the Azure DevOps project"
-  type        = string
+variable "contributors_groups" {
+  description = "List of groups that will be contributors at the Azure DevOps project"
+  type        = list(string)
 }
 
-variable "group_administrators" {
-  description = "Group that will be the administrator at the Azure DevOps project"
-  type        = string
+variable "administrators_groups" {
+  description = "List of groups that will be administrators at the Azure DevOps project"
+  type        = list(string)
 }
 
-variable "group_readers" {
-  description = "Group that will be the readers at the Azure DevOps project"
-  type        = string
+variable "readers_groups" {
+  description = "List of groups that will be readers at the Azure DevOps project"
+  type        = list(string)
 }
+
+# variable "service_connections" {
+#   type = object({
+#     azure = list(object({
+#       name = string
+#       managed_identity_name = string
+#       managed_identity_resource_group_name = string
+#     }))
+#   })
+# }


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->

The main goal of this PR is to allow the possibility of assign multiple owners to the same Azure DevOps project

## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [X] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [X] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix.
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->
- Add single/multiple readers groups
- Add single/multiple readers contributors
- Add single/multiple administrator groups
### How to test it
<!-- Please describe how to test it. -->

### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
