### PR TITLE
feature(key_vault): add control for public network availability

### DIFF
--- a/azure/key_vault/README.md
+++ b/azure/key_vault/README.md
@@ -16,13 +16,13 @@ keyvault when need.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.70 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.117 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.70 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.117.1 |
 
 ## Modules
 
@@ -33,6 +33,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [azurerm_key_vault.key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault) | resource |
+| [azurerm_key_vault_access_policy.administrators_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.default_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.readers_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.writers_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
@@ -42,11 +43,14 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_access_policies"></a> [access\_policies](#input\_access\_policies) | (Optional) Access policies created for the Azure Key Vault. | <pre>list(object({<br>    name      = string<br>    object_id = string<br>    type      = string<br>  }))</pre> | `[]` | no |
+| <a name="input_access_policies"></a> [access\_policies](#input\_access\_policies) | (Optional) Access policies created for the Azure Key Vault. | <pre>list(object({<br/>    name      = string<br/>    object_id = string<br/>    type      = string<br/>  }))</pre> | `[]` | no |
+| <a name="input_company_prefix"></a> [company\_prefix](#input\_company\_prefix) | Short, unique prefix for the company or organization. Used in naming for uniqueness. Must be 1-5 characters. | `string` | `"nmbrs"` | no |
 | <a name="input_enable_rbac_authorization"></a> [enable\_rbac\_authorization](#input\_enable\_rbac\_authorization) | Boolean flag to specify whether Azure Key Vault uses Role Based Access Control (RBAC) for authorization of data actions. | `bool` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment in which the resource should be provisioned. | `string` | n/a | yes |
 | <a name="input_external_usage"></a> [external\_usage](#input\_external\_usage) | (Optional) Specifies whether the keyvault should be used internally or externally. | `bool` | `true` | no |
 | <a name="input_location"></a> [location](#input\_location) | The location where the resources will be deployed in Azure. For an exaustive list of locations, please use the command 'az account list-locations -o table'. | `string` | n/a | yes |
+| <a name="input_override_name"></a> [override\_name](#input\_override\_name) | Override the name of the key vault, to bypass naming convention | `string` | `null` | no |
+| <a name="input_public_network_access_enabled"></a> [public\_network\_access\_enabled](#input\_public\_network\_access\_enabled) | A condition to indicate if the Key Vault will have public network access (defaults to false). | `bool` | `false` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of an existing Resource Group. | `string` | n/a | yes |
 | <a name="input_workload"></a> [workload](#input\_workload) | The workload name of the key vault. | `string` | n/a | yes |
 

--- a/azure/key_vault/local.tf
+++ b/azure/key_vault/local.tf
@@ -1,5 +1,9 @@
 locals {
-  key_vault_name = var.override_name != "" && var.override_name != null ? var.override_name : lower("kv-nmbrs-${var.workload}-${var.external_usage ? "e" : "i"}-${var.environment}")
+  key_vault_name = (
+    var.override_name != null && trimspace(var.override_name) != "" ?
+    lower(var.override_name) :
+    lower("kv${var.company_prefix}${var.workload}${var.external_usage ? "e" : "i"}${var.environment}")
+  )
 
   certificates_full_permissions = ["Backup", "Create", "Delete", "DeleteIssuers", "Get", "GetIssuers", "Import", "List", "ListIssuers", "ManageContacts", "ManageIssuers", "Purge", "Recover", "Restore", "SetIssuers", "Update"]
   keys_full_permissions         = []

--- a/azure/key_vault/main.tf
+++ b/azure/key_vault/main.tf
@@ -2,20 +2,16 @@ data "azurerm_client_config" "current" {}
 
 # Create the Azure Key Vault
 resource "azurerm_key_vault" "key_vault" {
-  name                       = local.key_vault_name
-  location                   = var.location
-  resource_group_name        = var.resource_group_name
-  tenant_id                  = data.azurerm_client_config.current.tenant_id
-  sku_name                   = "standard"
-  soft_delete_retention_days = 31
-  purge_protection_enabled   = true
-  enable_rbac_authorization  = var.enable_rbac_authorization
+  name                = local.key_vault_name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
 
-  network_acls {
-    #tfsec:ignore:azure-keyvault-specify-network-acl
-    default_action = "Allow"
-    bypass         = "AzureServices"
-  }
+  sku_name                      = "standard"
+  soft_delete_retention_days    = 31
+  purge_protection_enabled      = true
+  enable_rbac_authorization     = var.enable_rbac_authorization
+  public_network_access_enabled = var.public_network_access_enabled
 
   lifecycle {
     ignore_changes = [tags]

--- a/azure/key_vault/variables.tf
+++ b/azure/key_vault/variables.tf
@@ -1,8 +1,3 @@
-variable "resource_group_name" {
-  type        = string
-  description = "The name of an existing Resource Group."
-}
-
 variable "workload" {
   description = "The workload name of the key vault."
   type        = string
@@ -11,6 +6,11 @@ variable "workload" {
     condition     = length(var.workload) <= 8
     error_message = format("Invalid value '%s' for variable 'workload'. It must contain no more than 8 characters.", var.workload)
   }
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "The name of an existing Resource Group."
 }
 
 variable "location" {
@@ -69,4 +69,20 @@ variable "override_name" {
   type        = string
   default     = null
   nullable    = true
+}
+
+variable "company_prefix" {
+  description = "Short, unique prefix for the company or organization. Used in naming for uniqueness. Must be 1-5 characters."
+  type        = string
+  default     = "nmbrs"
+  validation {
+    condition     = length(trimspace(var.company_prefix)) > 0 && length(var.company_prefix) <= 5
+    error_message = "company_prefix must be a non-empty string with a maximum of 5 characters."
+  }
+}
+
+variable "public_network_access_enabled" {
+  description = "A condition to indicate if the Key Vault will have public network access (defaults to false)."
+  type        = bool
+  default     = false
 }


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->

The main goal of this PR is to introduce  the parameter `public_network_access_enabled` to the Key Vault module. This parameter allows users to control whether the Key Vault is publicly accessible or restricted to private networks.

## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [X] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [ ] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix.
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->

### How to test it
<!-- Please describe how to test it. -->

### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [X] Yes.
- [ ] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
