### PR TITLE
fix(storage_account): add control for public network availability 

### DIFF
--- a/azure/storage_account/README.md
+++ b/azure/storage_account/README.md
@@ -1,3 +1,4 @@
+<!-- BEGIN_TF_DOCS -->
 # Azure Storage Account Module
 
 ## Sumary
@@ -9,13 +10,13 @@ The `storage_account` module is an abstraction that implements all the necessary
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.70 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.117 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.70 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.117.1 |
 
 ## Modules
 
@@ -32,11 +33,14 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_kind"></a> [account\_kind](#input\_account\_kind) | Defines the Kind of storage account. | `string` | n/a | yes |
-| <a name="input_account_tier"></a> [account\_tier](#input\_account\_tier) | Defines the Tier to use for this storage account. | `string` | n/a | yes |
+| <a name="input_company_prefix"></a> [company\_prefix](#input\_company\_prefix) | Short, unique prefix for the company or organization. Used in naming for uniqueness. Must be 1-5 characters. | `string` | `"nmbrs"` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | (Optional) The environment in which the resource should be provisioned. | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | The location where the resources will be deployed in Azure. For an exaustive list of locations, please use the command 'az account list-locations -o table'. | `string` | n/a | yes |
+| <a name="input_override_name"></a> [override\_name](#input\_override\_name) | Optional override for naming logic. If set, this value is used for the resource name. | `string` | `null` | no |
+| <a name="input_public_network_access_enabled"></a> [public\_network\_access\_enabled](#input\_public\_network\_access\_enabled) | A condition to indicate if the Storage Account will have public network access (defaults to false). | `bool` | `false` | no |
 | <a name="input_replication_type"></a> [replication\_type](#input\_replication\_type) | Defines the type of replication to use for this storage account. | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of an existing Resource Group. | `string` | n/a | yes |
+| <a name="input_sku_name"></a> [sku\_name](#input\_sku\_name) | Defines the SKU name to use for this storage account. | `string` | n/a | yes |
 | <a name="input_workload"></a> [workload](#input\_workload) | The workload name of the storage account. | `string` | n/a | yes |
 
 ## Outputs
@@ -55,15 +59,37 @@ No modules.
 
 A number of code snippets demonstrating different use cases for the module have been included to help you understand how to use the module in Terraform.
 
+### Storage Account with Public Network Access Enabled
 ```hcl
 module "storage_account" {
-  source                = "git::github.com/Nmbrs/tf-modules/azure/storage_account"
-  workload              = "demo"
-  resource_group_name   = "rg-my-resource-group"
-  account_kind          = "Storage"
-  account_tier          = "Standard"
-  replication_type      = "GRS"
-  environment           = "dev"
-  location              = "westeurope"
+  source                        = "git::github.com/Nmbrs/tf-modules/azure/storage_account"
+  workload                      = "demo"
+  resource_group_name           = "rg-my-resource-group"
+  account_kind                  = "StorageV2"
+  sku_name                      = "Standard_LRS"
+  replication_type              = "LRS"
+  environment                   = "prod"
+  location                      = "westeurope"
+  company_prefix                = "myorg"
+  override_name                 = null
+  public_network_access_enabled = true
 }
 ```
+
+### Storage Account with Public Network Access Disabled
+```hcl
+module "storage_account" {
+  source                        = "git::github.com/Nmbrs/tf-modules/azure/storage_account"
+  workload                      = "demo"
+  resource_group_name           = "rg-my-resource-group"
+  account_kind                  = "StorageV2"
+  sku_name                      = "Standard_GRS"
+  replication_type              = "GRS"
+  environment                   = "dev"
+  location                      = "westeurope"
+  company_prefix                = "myorg"
+  override_name                 = null
+  public_network_access_enabled = false
+}
+```
+<!-- END_TF_DOCS -->

--- a/azure/storage_account/local.tf
+++ b/azure/storage_account/local.tf
@@ -1,3 +1,7 @@
 locals {
-  storage_account_name = lower("sanmbrs${var.workload}${var.environment}")
+  storage_account_name = (
+    var.override_name != null && var.override_name != "" ?
+    lower(var.override_name) :
+    lower("sa${var.company_prefix}${var.workload}${var.environment}")
+  )
 }

--- a/azure/storage_account/main.tf
+++ b/azure/storage_account/main.tf
@@ -1,14 +1,16 @@
 resource "azurerm_storage_account" "storage_account" {
-  name                       = local.storage_account_name
-  resource_group_name        = var.resource_group_name
-  location                   = var.location
-  account_kind               = var.account_kind
-  account_tier               = var.account_tier
-  account_replication_type   = var.replication_type
-  https_traffic_only_enabled = true
-  min_tls_version            = "TLS1_2"
+  name                          = local.storage_account_name
+  resource_group_name           = var.resource_group_name
+  location                      = var.location
+  account_kind                  = var.account_kind
+  account_tier                  = var.sku_name
+  account_replication_type      = var.replication_type
+  https_traffic_only_enabled    = true
+  min_tls_version               = "TLS1_2"
+  public_network_access_enabled = var.public_network_access_enabled
 
   lifecycle {
     ignore_changes = [tags]
   }
+
 }

--- a/azure/storage_account/variables.tf
+++ b/azure/storage_account/variables.tf
@@ -43,13 +43,13 @@ variable "account_kind" {
   }
 }
 
-variable "account_tier" {
-  description = "Defines the Tier to use for this storage account."
+variable "sku_name" {
+  description = "Defines the SKU name to use for this storage account."
   type        = string
 
   validation {
-    condition     = contains(["Standard", "Premium"], var.account_tier)
-    error_message = "The account_tier value is invalid. Valid options are 'Standard' and 'Premium'."
+    condition     = contains(["Standard", "Premium"], var.sku_name)
+    error_message = "The sku_name value is invalid. Valid options are 'Standard' and 'Premium'."
   }
 }
 
@@ -61,4 +61,27 @@ variable "replication_type" {
     condition     = contains(["LRS", "GRS", "RAGS", "ZRS", "GZRS", "RAGZRS"], var.replication_type)
     error_message = "The replication_type value is invalid. Valid options are LRS, GRS, RAGRS, ZRS, GZRS and RAGZRS."
   }
+}
+
+variable "company_prefix" {
+  description = "Short, unique prefix for the company or organization. Used in naming for uniqueness. Must be 1-5 characters."
+  type        = string
+  default     = "nmbrs"
+  validation {
+    condition     = length(trimspace(var.company_prefix)) > 0 && length(var.company_prefix) <= 5
+    error_message = "company_prefix must be a non-empty string with a maximum of 5 characters."
+  }
+}
+
+variable "override_name" {
+  description = "Optional override for naming logic. If set, this value is used for the resource name."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "public_network_access_enabled" {
+  description = "A condition to indicate if the Storage Account will have public network access (defaults to false)."
+  type        = bool
+  default     = false
 }


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->

The main goal of this PR is to introduce  the parameter `public_network_access_enabled` to the storage_account module. This parameter allows users to control whether the Key Vault is publicly accessible or restricted to private networks.

## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [X] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [ ] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix.
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->

### How to test it
<!-- Please describe how to test it. -->

### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [X] Yes.
- [ ] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
